### PR TITLE
refactor: remove line numbers from `Range`

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -10,7 +10,7 @@
     "./benches/json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.12.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.12.1.wasm",
     "https://plugins.dprint.dev/rustfmt-0.4.0.exe-plugin@c6bb223ef6e5e87580177f6461a0ab0554ac9ea6b54f78ea7ae8bf63b14f5bc2"
   ]
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,16 +2,9 @@
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Range {
   /// Start position of the node in the text.
-  pub start: Position,
+  pub start: usize,
   /// End position of the node in the text.
-  pub end: Position,
-}
-
-impl Range {
-  /// Gets the end byte index minus the start byte index of the range.
-  pub fn width(&self) -> usize {
-    self.end.index - self.start.index
-  }
+  pub end: usize,
 }
 
 impl Ranged for Range {
@@ -27,81 +20,23 @@ pub trait Ranged {
 
   /// Gets the byte index of the first character in the text.
   fn start(&self) -> usize {
-    self.range().start.index
-  }
-
-  /// Gets the line number of the start position in the text.
-  fn start_line(&self) -> usize {
-    self.range().start.line
+    self.range().start
   }
 
   /// Gets the byte index after the last character in the text.
   fn end(&self) -> usize {
-    self.range().end.index
-  }
-
-  /// Gets the line number of the end position in the text.
-  fn end_line(&self) -> usize {
-    self.range().end.line
+    self.range().end
   }
 
   /// Gets the text from the provided string.
   fn text<'a>(&self, text: &'a str) -> &'a str {
-    &text[self.start()..self.end()]
-  }
-
-  /// Gets the start position.
-  fn start_position(&self) -> &Position {
     let range = self.range();
-    &range.start
-  }
-
-  /// Gets the end byte position.
-  fn end_position(&self) -> &Position {
-    let range = self.range();
-    &range.end
+    &text[range.start..range.end]
   }
 
   /// Gets the end byte index minus the start byte index of the range.
   fn width(&self) -> usize {
-    self.range().width()
-  }
-}
-
-/// Ranged value that specifies a specific position in the file.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub struct Position {
-  /// Byte index of the node in the text.
-  pub index: usize,
-  /// Line of the position of the node in the text.
-  pub line: usize,
-}
-
-impl Position {
-  /// Creates a new position at the specified position and line.
-  pub fn new(pos: usize, line: usize) -> Position {
-    Position { index: pos, line }
-  }
-
-  /// Gets the column index from the provided file text.
-  pub fn column_index(&self, file_text: &str) -> usize {
-    let mut column_number = 0;
-    for (indice, c) in file_text.char_indices() {
-      if c == '\n' {
-        column_number = 0;
-      } else if indice >= self.index {
-        break;
-      } else {
-        column_number += 1;
-      }
-    }
-    column_number
-  }
-
-  pub fn as_range(&self) -> Range {
-    Range {
-      start: *self,
-      end: *self,
-    }
+    let range = self.range();
+    range.end - range.start
   }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,10 +38,15 @@ impl Error for ParseError {
 }
 
 fn get_message_with_range(range: &Range, message: &str, file_text: &str) -> String {
-  return format!(
-    "{} on line {} column {}.",
-    message,
-    range.start.line + 1,
-    range.start.column_index(file_text) + 1,
-  );
+  let mut line_index = 0;
+  let mut column_index = 0;
+  for c in file_text[0..range.start as usize].chars() {
+    if c == '\n' {
+      line_index += 1;
+      column_index = 0;
+    } else {
+      column_index += 1;
+    }
+  }
+  format!("{} on line {} column {}.", message, line_index + 1, column_index + 1,)
 }

--- a/src/parse_to_ast.rs
+++ b/src/parse_to_ast.rs
@@ -1,5 +1,3 @@
-use crate::common::Position;
-
 use super::ast::*;
 use super::common::Range;
 use super::errors::*;
@@ -85,11 +83,8 @@ impl<'a> Context<'a> {
 
   pub fn start_range(&mut self) {
     self.range_stack.push(Range {
-      start: Position {
-        index: self.scanner.token_start(),
-        line: self.scanner.token_start_line(),
-      },
-      end: Position { index: 0, line: 0 },
+      start: self.scanner.token_start(),
+      end: 0,
     });
   }
 
@@ -98,21 +93,14 @@ impl<'a> Context<'a> {
       .range_stack
       .pop()
       .expect("Range was popped from the stack, but the stack was empty.");
-    range.end.index = self.scanner.token_end();
-    range.end.line = self.scanner.token_end_line();
+    range.end = self.scanner.token_end();
     range
   }
 
   pub fn create_range_from_last_token(&self) -> Range {
     Range {
-      start: Position {
-        index: self.scanner.token_start(),
-        line: self.scanner.token_start_line(),
-      },
-      end: Position {
-        index: self.scanner.token_end(),
-        line: self.scanner.token_end_line(),
-      },
+      start: self.scanner.token_start(),
+      end: self.scanner.token_end(),
     }
   }
 

--- a/src/parse_to_value.rs
+++ b/src/parse_to_value.rs
@@ -137,9 +137,8 @@ mod tests {
   #[test]
   fn error_unexpected_token() {
     let err = parse_to_value("{\n  \"a\":\u{200b}5 }").err().unwrap();
-    assert_eq!(err.range.start.line, 1);
-    assert_eq!(err.range.start.index, 8);
-    assert_eq!(err.range.end.index, 11);
+    assert_eq!(err.range.start, 8);
+    assert_eq!(err.range.end, 11);
     assert_eq!(err.message, "Unexpected token");
   }
 }

--- a/tests/specs/array/array.txt
+++ b/tests/specs/array/array.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 55,
-      "startLine": 0,
-      "endLine": 0
     },
     "elements": [
       {
@@ -13,8 +11,6 @@
         "range": {
           "start": 1,
           "end": 7,
-          "startLine": 0,
-          "endLine": 0
         },
         "value": "test"
       },
@@ -23,8 +19,6 @@
         "range": {
           "start": 9,
           "end": 10,
-          "startLine": 0,
-          "endLine": 0
         },
         "value": "5"
       },
@@ -33,8 +27,6 @@
         "range": {
           "start": 12,
           "end": 25,
-          "startLine": 0,
-          "endLine": 0
         },
         "properties": [
           {
@@ -42,16 +34,12 @@
             "range": {
               "start": 14,
               "end": 23,
-              "startLine": 0,
-              "endLine": 0
             },
             "name": {
               "type": "string",
               "range": {
                 "start": 14,
                 "end": 20,
-                "startLine": 0,
-                "endLine": 0
               },
               "value": "prop"
             },
@@ -60,8 +48,6 @@
               "range": {
                 "start": 22,
                 "end": 23,
-                "startLine": 0,
-                "endLine": 0
               },
               "value": "4"
             }
@@ -73,8 +59,6 @@
         "range": {
           "start": 27,
           "end": 35,
-          "startLine": 0,
-          "endLine": 0
         },
         "elements": [
           {
@@ -82,8 +66,6 @@
             "range": {
               "start": 28,
               "end": 34,
-              "startLine": 0,
-              "endLine": 0
             },
             "value": "test"
           }
@@ -94,8 +76,6 @@
         "range": {
           "start": 37,
           "end": 41,
-          "startLine": 0,
-          "endLine": 0
         },
         "value": "true"
       },
@@ -104,8 +84,6 @@
         "range": {
           "start": 43,
           "end": 48,
-          "startLine": 0,
-          "endLine": 0
         },
         "value": "false"
       },
@@ -114,8 +92,6 @@
         "range": {
           "start": 50,
           "end": 54,
-          "startLine": 0,
-          "endLine": 0
         }
       }
     ]

--- a/tests/specs/array/empty-array.txt
+++ b/tests/specs/array/empty-array.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 2,
-      "startLine": 0,
-      "endLine": 0
     },
     "elements": [
     ]

--- a/tests/specs/array/trailing_comma.txt
+++ b/tests/specs/array/trailing_comma.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 4,
-      "startLine": 0,
-      "endLine": 0
     },
     "elements": [
       {
@@ -13,8 +11,6 @@
         "range": {
           "start": 1,
           "end": 2,
-          "startLine": 0,
-          "endLine": 0
         },
         "value": "1"
       }

--- a/tests/specs/comments/inline-comments.txt
+++ b/tests/specs/comments/inline-comments.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 5,
       "end": 102,
-      "startLine": 0,
-      "endLine": 4
     },
     "properties": [
       {
@@ -13,16 +11,12 @@
         "range": {
           "start": 21,
           "end": 37,
-          "startLine": 1,
-          "endLine": 1
         },
         "name": {
           "type": "string",
           "range": {
             "start": 21,
             "end": 24,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "a"
         },
@@ -31,8 +25,6 @@
           "range": {
             "start": 36,
             "end": 37,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "5"
         }
@@ -42,16 +34,12 @@
         "range": {
           "start": 52,
           "end": 69,
-          "startLine": 2,
-          "endLine": 2
         },
         "name": {
           "type": "string",
           "range": {
             "start": 52,
             "end": 55,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "b"
         },
@@ -60,8 +48,6 @@
           "range": {
             "start": 62,
             "end": 69,
-            "startLine": 2,
-            "endLine": 2
           },
           "elements": [
           ]
@@ -72,16 +58,12 @@
         "range": {
           "start": 85,
           "end": 94,
-          "startLine": 3,
-          "endLine": 3
         },
         "name": {
           "type": "string",
           "range": {
             "start": 85,
             "end": 88,
-            "startLine": 3,
-            "endLine": 3
           },
           "value": "c"
         },
@@ -90,8 +72,6 @@
           "range": {
             "start": 90,
             "end": 94,
-            "startLine": 3,
-            "endLine": 3
           }
         }
       }
@@ -106,8 +86,6 @@
           "range": {
             "start": 0,
             "end": 5,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": "1"
         }
@@ -121,8 +99,6 @@
           "range": {
             "start": 0,
             "end": 5,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": "1"
         }
@@ -136,8 +112,6 @@
           "range": {
             "start": 7,
             "end": 11,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": " 2"
         },
@@ -146,8 +120,6 @@
           "range": {
             "start": 16,
             "end": 21,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "3"
         }
@@ -161,8 +133,6 @@
           "range": {
             "start": 7,
             "end": 11,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": " 2"
         },
@@ -171,8 +141,6 @@
           "range": {
             "start": 16,
             "end": 21,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "3"
         }
@@ -186,8 +154,6 @@
           "range": {
             "start": 24,
             "end": 29,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "4"
         }
@@ -201,8 +167,6 @@
           "range": {
             "start": 24,
             "end": 29,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "4"
         }
@@ -216,8 +180,6 @@
           "range": {
             "start": 31,
             "end": 36,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "5"
         }
@@ -231,8 +193,6 @@
           "range": {
             "start": 31,
             "end": 36,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "5"
         }
@@ -246,8 +206,6 @@
           "range": {
             "start": 37,
             "end": 42,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "6"
         }
@@ -261,8 +219,6 @@
           "range": {
             "start": 37,
             "end": 42,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "6"
         }
@@ -276,8 +232,6 @@
           "range": {
             "start": 44,
             "end": 47,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "7"
         }
@@ -291,8 +245,6 @@
           "range": {
             "start": 44,
             "end": 47,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "7"
         }
@@ -306,8 +258,6 @@
           "range": {
             "start": 57,
             "end": 62,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "8"
         }
@@ -321,8 +271,6 @@
           "range": {
             "start": 57,
             "end": 62,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "8"
         }
@@ -336,8 +284,6 @@
           "range": {
             "start": 63,
             "end": 68,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "9"
         }
@@ -351,8 +297,6 @@
           "range": {
             "start": 63,
             "end": 68,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "9"
         }
@@ -366,8 +310,6 @@
           "range": {
             "start": 69,
             "end": 75,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "10"
         }
@@ -381,8 +323,6 @@
           "range": {
             "start": 69,
             "end": 75,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "10"
         }
@@ -396,8 +336,6 @@
           "range": {
             "start": 76,
             "end": 80,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "11"
         }
@@ -411,8 +349,6 @@
           "range": {
             "start": 76,
             "end": 80,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "11"
         }
@@ -426,8 +362,6 @@
           "range": {
             "start": 95,
             "end": 101,
-            "startLine": 4,
-            "endLine": 4
           },
           "value": "13"
         }
@@ -441,8 +375,6 @@
           "range": {
             "start": 95,
             "end": 101,
-            "startLine": 4,
-            "endLine": 4
           },
           "value": "13"
         }
@@ -456,8 +388,6 @@
           "range": {
             "start": 103,
             "end": 108,
-            "startLine": 4,
-            "endLine": 4
           },
           "value": " 14"
         }
@@ -471,8 +401,6 @@
           "range": {
             "start": 103,
             "end": 108,
-            "startLine": 4,
-            "endLine": 4
           },
           "value": " 14"
         }

--- a/tests/specs/comments/only-comments.txt
+++ b/tests/specs/comments/only-comments.txt
@@ -9,8 +9,6 @@
           "range": {
             "start": 0,
             "end": 10,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": " testing"
         },
@@ -19,8 +17,6 @@
           "range": {
             "start": 11,
             "end": 21,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": " test "
         },
@@ -29,8 +25,6 @@
           "range": {
             "start": 22,
             "end": 29,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": " test"
         },
@@ -39,8 +33,6 @@
           "range": {
             "start": 30,
             "end": 47,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "test /* test */"
         }
@@ -54,8 +46,6 @@
           "range": {
             "start": 0,
             "end": 10,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": " testing"
         },
@@ -64,8 +54,6 @@
           "range": {
             "start": 11,
             "end": 21,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": " test "
         },
@@ -74,8 +62,6 @@
           "range": {
             "start": 22,
             "end": 29,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": " test"
         },
@@ -84,8 +70,6 @@
           "range": {
             "start": 30,
             "end": 47,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "test /* test */"
         }

--- a/tests/specs/encoding/encoding.txt
+++ b/tests/specs/encoding/encoding.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 16,
       "end": 23,
-      "startLine": 1,
-      "endLine": 1
     },
     "value": "2: ß"
   },
@@ -18,8 +16,6 @@
           "range": {
             "start": 0,
             "end": 15,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": " 3 bytes: ℝ"
         }
@@ -33,8 +29,6 @@
           "range": {
             "start": 0,
             "end": 15,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": " 3 bytes: ℝ"
         }

--- a/tests/specs/object/empty-object.txt
+++ b/tests/specs/object/empty-object.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 2,
-      "startLine": 0,
-      "endLine": 0
     },
     "properties": [
     ]

--- a/tests/specs/object/non-string-prop-names.txt
+++ b/tests/specs/object/non-string-prop-names.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 108,
-      "startLine": 0,
-      "endLine": 7
     },
     "properties": [
       {
@@ -13,16 +11,12 @@
         "range": {
           "start": 6,
           "end": 20,
-          "startLine": 1,
-          "endLine": 1
         },
         "name": {
           "type": "word",
           "range": {
             "start": 6,
             "end": 12,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "myProp"
         },
@@ -31,8 +25,6 @@
           "range": {
             "start": 14,
             "end": 20,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "test"
         }
@@ -42,16 +34,12 @@
         "range": {
           "start": 26,
           "end": 39,
-          "startLine": 2,
-          "endLine": 2
         },
         "name": {
           "type": "word",
           "range": {
             "start": 26,
             "end": 31,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "other"
         },
@@ -60,8 +48,6 @@
           "range": {
             "start": 33,
             "end": 39,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "asdf"
         }
@@ -71,16 +57,12 @@
         "range": {
           "start": 45,
           "end": 62,
-          "startLine": 3,
-          "endLine": 3
         },
         "name": {
           "type": "word",
           "range": {
             "start": 45,
             "end": 54,
-            "startLine": 3,
-            "endLine": 3
           },
           "value": "asdf-test"
         },
@@ -89,8 +71,6 @@
           "range": {
             "start": 56,
             "end": 62,
-            "startLine": 3,
-            "endLine": 3
           },
           "value": "test"
         }
@@ -100,16 +80,12 @@
         "range": {
           "start": 68,
           "end": 77,
-          "startLine": 4,
-          "endLine": 4
         },
         "name": {
           "type": "word",
           "range": {
             "start": 68,
             "end": 73,
-            "startLine": 4,
-            "endLine": 4
           },
           "value": "oo43o"
         },
@@ -118,8 +94,6 @@
           "range": {
             "start": 76,
             "end": 77,
-            "startLine": 4,
-            "endLine": 4
           },
           "value": "5"
         }
@@ -129,16 +103,12 @@
         "range": {
           "start": 83,
           "end": 92,
-          "startLine": 5,
-          "endLine": 5
         },
         "name": {
           "type": "word",
           "range": {
             "start": 83,
             "end": 88,
-            "startLine": 5,
-            "endLine": 5
           },
           "value": "jnm44"
         },
@@ -147,8 +117,6 @@
           "range": {
             "start": 91,
             "end": 92,
-            "startLine": 5,
-            "endLine": 5
           },
           "value": "3"
         }
@@ -158,16 +126,12 @@
         "range": {
           "start": 98,
           "end": 106,
-          "startLine": 6,
-          "endLine": 6
         },
         "name": {
           "type": "word",
           "range": {
             "start": 98,
             "end": 101,
-            "startLine": 6,
-            "endLine": 6
           },
           "value": "456"
         },
@@ -176,8 +140,6 @@
           "range": {
             "start": 104,
             "end": 106,
-            "startLine": 6,
-            "endLine": 6
           },
           "value": "34"
         }

--- a/tests/specs/object/object.txt
+++ b/tests/specs/object/object.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 159,
-      "startLine": 0,
-      "endLine": 10
     },
     "properties": [
       {
@@ -13,16 +11,12 @@
         "range": {
           "start": 6,
           "end": 17,
-          "startLine": 1,
-          "endLine": 1
         },
         "name": {
           "type": "string",
           "range": {
             "start": 6,
             "end": 14,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "number"
         },
@@ -31,8 +25,6 @@
           "range": {
             "start": 16,
             "end": 17,
-            "startLine": 1,
-            "endLine": 1
           },
           "value": "5"
         }
@@ -42,16 +34,12 @@
         "range": {
           "start": 23,
           "end": 44,
-          "startLine": 2,
-          "endLine": 2
         },
         "name": {
           "type": "string",
           "range": {
             "start": 23,
             "end": 31,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "string"
         },
@@ -60,8 +48,6 @@
           "range": {
             "start": 33,
             "end": 44,
-            "startLine": 2,
-            "endLine": 2
           },
           "value": "str\\test"
         }
@@ -71,16 +57,12 @@
         "range": {
           "start": 50,
           "end": 84,
-          "startLine": 3,
-          "endLine": 5
         },
         "name": {
           "type": "string",
           "range": {
             "start": 50,
             "end": 58,
-            "startLine": 3,
-            "endLine": 3
           },
           "value": "object"
         },
@@ -89,8 +71,6 @@
           "range": {
             "start": 60,
             "end": 84,
-            "startLine": 3,
-            "endLine": 5
           },
           "properties": [
             {
@@ -98,16 +78,12 @@
               "range": {
                 "start": 70,
                 "end": 78,
-                "startLine": 4,
-                "endLine": 4
               },
               "name": {
                 "type": "string",
                 "range": {
                   "start": 70,
                   "end": 75,
-                  "startLine": 4,
-                  "endLine": 4
                 },
                 "value": "obj"
               },
@@ -116,8 +92,6 @@
                 "range": {
                   "start": 77,
                   "end": 78,
-                  "startLine": 4,
-                  "endLine": 4
                 },
                 "value": "5"
               }
@@ -130,16 +104,12 @@
         "range": {
           "start": 90,
           "end": 101,
-          "startLine": 6,
-          "endLine": 6
         },
         "name": {
           "type": "string",
           "range": {
             "start": 90,
             "end": 97,
-            "startLine": 6,
-            "endLine": 6
           },
           "value": "array"
         },
@@ -148,8 +118,6 @@
           "range": {
             "start": 99,
             "end": 101,
-            "startLine": 6,
-            "endLine": 6
           },
           "elements": [
           ]
@@ -160,16 +128,12 @@
         "range": {
           "start": 107,
           "end": 119,
-          "startLine": 7,
-          "endLine": 7
         },
         "name": {
           "type": "string",
           "range": {
             "start": 107,
             "end": 113,
-            "startLine": 7,
-            "endLine": 7
           },
           "value": "true"
         },
@@ -178,8 +142,6 @@
           "range": {
             "start": 115,
             "end": 119,
-            "startLine": 7,
-            "endLine": 7
           },
           "value": "true"
         }
@@ -189,16 +151,12 @@
         "range": {
           "start": 125,
           "end": 139,
-          "startLine": 8,
-          "endLine": 8
         },
         "name": {
           "type": "string",
           "range": {
             "start": 125,
             "end": 132,
-            "startLine": 8,
-            "endLine": 8
           },
           "value": "false"
         },
@@ -207,8 +165,6 @@
           "range": {
             "start": 134,
             "end": 139,
-            "startLine": 8,
-            "endLine": 8
           },
           "value": "false"
         }
@@ -218,16 +174,12 @@
         "range": {
           "start": 145,
           "end": 157,
-          "startLine": 9,
-          "endLine": 9
         },
         "name": {
           "type": "string",
           "range": {
             "start": 145,
             "end": 151,
-            "startLine": 9,
-            "endLine": 9
           },
           "value": "null"
         },
@@ -236,8 +188,6 @@
           "range": {
             "start": 153,
             "end": 157,
-            "startLine": 9,
-            "endLine": 9
           }
         }
       }

--- a/tests/specs/object/trailing_comma.txt
+++ b/tests/specs/object/trailing_comma.txt
@@ -4,8 +4,6 @@
     "range": {
       "start": 0,
       "end": 11,
-      "startLine": 0,
-      "endLine": 0
     },
     "properties": [
       {
@@ -13,16 +11,12 @@
         "range": {
           "start": 2,
           "end": 8,
-          "startLine": 0,
-          "endLine": 0
         },
         "name": {
           "type": "string",
           "range": {
             "start": 2,
             "end": 5,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": "p"
         },
@@ -31,8 +25,6 @@
           "range": {
             "start": 7,
             "end": 8,
-            "startLine": 0,
-            "endLine": 0
           },
           "value": "1"
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -100,10 +100,8 @@ fn value_to_test_str(value: &Value) -> String {
 fn range_to_test_str(range: &Range) -> String {
   let mut text = String::new();
   text.push_str("\"range\": {\n");
-  text.push_str(&format!("  \"start\": {},\n", range.start.index));
-  text.push_str(&format!("  \"end\": {},\n", range.end.index));
-  text.push_str(&format!("  \"startLine\": {},\n", range.start.line));
-  text.push_str(&format!("  \"endLine\": {}\n", range.end.line));
+  text.push_str(&format!("  \"start\": {},\n", range.start));
+  text.push_str(&format!("  \"end\": {},\n", range.end));
   text.push_str("}");
   text
 }


### PR DESCRIPTION
Before:

```
running 6 tests
test citm_catalog_json_large_ast   ... bench:  60,868,160 ns/iter (+/- 15,914,736)
test citm_catalog_json_large_value ... bench:  84,421,400 ns/iter (+/- 5,477,151)
test package_json_ast              ... bench:      71,403 ns/iter (+/- 2,063)
test package_json_value            ... bench:     102,372 ns/iter (+/- 2,451)
test tsconfig_json_ast             ... bench:      22,892 ns/iter (+/- 169)
test tsconfig_json_value           ... bench:      23,427 ns/iter (+/- 294)
```

After:

```
running 6 tests
test citm_catalog_json_large_ast   ... bench:  60,168,560 ns/iter (+/- 12,514,796)
test citm_catalog_json_large_value ... bench:  79,542,220 ns/iter (+/- 2,981,058)
test package_json_ast              ... bench:      68,581 ns/iter (+/- 3,496)
test package_json_value            ... bench:      96,130 ns/iter (+/- 6,301)
test tsconfig_json_ast             ... bench:      21,284 ns/iter (+/- 712)
test tsconfig_json_value           ... bench:      22,433 ns/iter (+/- 1,536)
```

But also, this will use less memory. The line numbers should be computed if needed (ex. using text_lines https://crates.io/crates/text_lines)

Closes #23.