### PR TITLE
feat: ability to parse strictly as JSON

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+tab_spaces = 2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To a simple `JsonValue`:
 ```rs
 use jsonc_parser::parse_to_value;
 
-let json_value = parse_to_value(r#"{ "test": 5 } // test"#)?;
+let json_value = parse_to_value(r#"{ "test": 5 } // test"#, &Default::default())?;
 // check the json_value here
 ```
 
@@ -19,13 +19,12 @@ Or an AST:
 
 ```rs
 use jsonc_parser::parse_to_ast;
-use jsonc_parser::ParseOptions;
+use jsonc_parser::CollectOptions;
 
-let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &ParseOptions {
-    collect_comments: true, // include comments in result
-    collect_tokens: true, // include tokens in result
-    ..Default::default()
-})?;
+let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &CollectOptions {
+    comments: true, // include comments in result
+    tokens: true, // include tokens in result
+}, &Default::default())?;
 // ...inspect parse_result for value, tokens, and comments here...
 ```
 
@@ -39,5 +38,20 @@ jsonc-parser = { version = "...", features = ["serde"] }
 ```rs
 use jsonc_parser::parse_to_serde_value;
 
-let json_value = parse_to_serde_value(r#"{ "test": 5 } // test"#)?;
+let json_value = parse_to_serde_value(r#"{ "test": 5 } // test"#, &Default::default())?;
+```
+
+## Parse Strictly as JSON
+
+Provide `ParseOptions` and set all the options to false:
+
+```rs
+use jsonc_parser::parse_to_value;
+use jsonc_parser::ParseOptions;
+
+let json_value = parse_to_value(text, &ParseOptions {
+  allow_comments: false,
+  allow_loose_object_property_names: false,
+  allow_trailing_commas: false,
+})?;
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ use jsonc_parser::{parse_to_ast, ParseOptions};
 let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &ParseOptions {
     comments: true, // include comments in result
     tokens: true, // include tokens in result
+    strict: false, // whether to be strict and only parse as JSON
 })?;
 // ...inspect parse_result for value, tokens, and comments here...
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ use jsonc_parser::{parse_to_ast, ParseOptions};
 let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &ParseOptions {
     comments: true, // include comments in result
     tokens: true, // include tokens in result
-    strict: false, // whether to be strict and only parse as JSON
+    ..Default::default()
 })?;
 // ...inspect parse_result for value, tokens, and comments here...
 ```

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ let json_value = parse_to_value(r#"{ "test": 5 } // test"#)?;
 Or an AST:
 
 ```rs
-use jsonc_parser::{parse_to_ast, ParseOptions};
+use jsonc_parser::parse_to_ast;
+use jsonc_parser::ParseOptions;
 
 let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &ParseOptions {
-    comments: true, // include comments in result
-    tokens: true, // include tokens in result
+    collect_comments: true, // include comments in result
+    collect_tokens: true, // include tokens in result
     ..Default::default()
 })?;
 // ...inspect parse_result for value, tokens, and comments here...

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,8 @@
 
 extern crate test;
 
-use jsonc_parser::{parse_to_ast, parse_to_value, ParseOptions};
+use jsonc_parser::parse_to_ast;
+use jsonc_parser::parse_to_value;
 use std::fs::read_to_string;
 use test::Bencher;
 
@@ -45,11 +46,11 @@ fn package_json_value(b: &mut Bencher) {
 // bench helpers
 
 fn bench_ast(b: &mut Bencher, json_text: &str) {
-  b.iter(|| parse_to_ast(json_text, &ParseOptions::default()).unwrap());
+  b.iter(|| parse_to_ast(json_text, &Default::default(), &Default::default()).unwrap());
 }
 
 fn bench_value(b: &mut Bencher, json_text: &str) {
-  b.iter(|| parse_to_value(json_text).unwrap());
+  b.iter(|| parse_to_value(json_text, &Default::default()).unwrap());
 }
 
 #[cfg(feature = "serde")]

--- a/dprint.json
+++ b/dprint.json
@@ -1,8 +1,9 @@
 {
   "incremental": true,
   "indentWidth": 2,
-  "rustfmt": {
-    "max_width": 120
+  "exec": {
+    "associations": "**/*.rs",
+    "rustfmt": "rustfmt"
   },
   "includes": ["**/*.{md,rs}"],
   "excludes": [
@@ -10,7 +11,7 @@
     "./benches/json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.12.1.wasm",
-    "https://plugins.dprint.dev/rustfmt-0.4.0.exe-plugin@c6bb223ef6e5e87580177f6461a0ab0554ac9ea6b54f78ea7ae8bf63b14f5bc2"
+    "https://plugins.dprint.dev/markdown-0.13.3.wasm",
+    "https://plugins.dprint.dev/exec-0.3.1.json@9351b67ec7a6b58a69201c2834cba38cb3d191080aefc6422fb1320f03c8fc4d"
   ]
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -441,14 +441,7 @@ mod test {
 
   #[test]
   fn it_should_take() {
-    let ast = parse_to_ast(
-      "{'prop': 'asdf', 'other': 'text'}",
-      &ParseOptions {
-        tokens: false,
-        comments: false,
-      },
-    )
-    .unwrap();
+    let ast = parse_to_ast("{'prop': 'asdf', 'other': 'text'}", &ParseOptions::default()).unwrap();
     let mut obj = match ast.value {
       Some(Value::Object(obj)) => obj,
       _ => unreachable!(),
@@ -469,14 +462,7 @@ mod test {
 
   #[test]
   fn it_should_get() {
-    let ast = parse_to_ast(
-      "{'prop': 'asdf'}",
-      &ParseOptions {
-        tokens: false,
-        comments: false,
-      },
-    )
-    .unwrap();
+    let ast = parse_to_ast("{'prop': 'asdf'}", &ParseOptions::default()).unwrap();
     let obj = match ast.value {
       Some(Value::Object(obj)) => obj,
       _ => unreachable!(),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -441,7 +441,12 @@ mod test {
 
   #[test]
   fn it_should_take() {
-    let ast = parse_to_ast("{'prop': 'asdf', 'other': 'text'}", &ParseOptions::default()).unwrap();
+    let ast = parse_to_ast(
+      "{'prop': 'asdf', 'other': 'text'}",
+      &Default::default(),
+      &ParseOptions::default(),
+    )
+    .unwrap();
     let mut obj = match ast.value {
       Some(Value::Object(obj)) => obj,
       _ => unreachable!(),
@@ -462,7 +467,7 @@ mod test {
 
   #[test]
   fn it_should_get() {
-    let ast = parse_to_ast("{'prop': 'asdf'}", &ParseOptions::default()).unwrap();
+    let ast = parse_to_ast("{'prop': 'asdf'}", &Default::default(), &ParseOptions::default()).unwrap();
     let obj = match ast.value {
       Some(Value::Object(obj)) => obj,
       _ => unreachable!(),

--- a/src/parse_to_value.rs
+++ b/src/parse_to_value.rs
@@ -17,8 +17,11 @@ pub fn parse_to_value(text: &str) -> Result<Option<JsonValue>, ParseError> {
   let value = parse_to_ast(
     text,
     &ParseOptions {
-      comments: false,
-      tokens: false,
+      collect_comments: false,
+      collect_tokens: false,
+      allow_comments: true,
+      allow_trailing_commas: true,
+      allow_loose_object_property_names: true,
     },
   )?
   .value;

--- a/src/parse_to_value.rs
+++ b/src/parse_to_value.rs
@@ -1,7 +1,9 @@
 use super::ast;
 use super::errors::ParseError;
+use super::parse_to_ast;
 use super::value::*;
-use super::{parse_to_ast, ParseOptions};
+use super::CollectOptions;
+use super::ParseOptions;
 use std::collections::HashMap;
 
 /// Parses a string containing JSONC to a `JsonValue`.
@@ -11,18 +13,16 @@ use std::collections::HashMap;
 /// ```
 /// use jsonc_parser::parse_to_value;
 ///
-/// let json_value = parse_to_value(r#"{ "test": 5 } // test"#).expect("Should parse.");
+/// let json_value = parse_to_value(r#"{ "test": 5 } // test"#, &Default::default()).expect("Should parse.");
 /// ```
-pub fn parse_to_value(text: &str) -> Result<Option<JsonValue>, ParseError> {
+pub fn parse_to_value<'a>(text: &'a str, options: &ParseOptions) -> Result<Option<JsonValue<'a>>, ParseError> {
   let value = parse_to_ast(
     text,
-    &ParseOptions {
-      collect_comments: false,
-      collect_tokens: false,
-      allow_comments: true,
-      allow_trailing_commas: true,
-      allow_loose_object_property_names: true,
+    &CollectOptions {
+      comments: false,
+      tokens: false,
     },
+    &options,
   )?
   .value;
   Ok(value.map(handle_value))
@@ -69,6 +69,7 @@ mod tests {
     "c": true,
     d: 25.55
 }"#,
+      &Default::default(),
     )
     .unwrap()
     .unwrap();
@@ -86,39 +87,43 @@ mod tests {
 
   #[test]
   fn it_should_parse_boolean_false() {
-    let value = parse_to_value("false").unwrap().unwrap();
+    let value = parse_to_value("false", &Default::default()).unwrap().unwrap();
     assert_eq!(value, JsonValue::Boolean(false));
-    let value = parse_to_value("true").unwrap().unwrap();
+    let value = parse_to_value("true", &Default::default()).unwrap().unwrap();
     assert_eq!(value, JsonValue::Boolean(true));
   }
 
   #[test]
   fn it_should_parse_boolean_true() {
-    let value = parse_to_value("true").unwrap().unwrap();
+    let value = parse_to_value("true", &Default::default()).unwrap().unwrap();
     assert_eq!(value, JsonValue::Boolean(true));
   }
 
   #[test]
   fn it_should_parse_number() {
-    let value = parse_to_value("50").unwrap().unwrap();
+    let value = parse_to_value("50", &Default::default()).unwrap().unwrap();
     assert_eq!(value, JsonValue::Number("50"));
   }
 
   #[test]
   fn it_should_parse_string() {
-    let value = parse_to_value(r#""test""#).unwrap().unwrap();
+    let value = parse_to_value(r#""test""#, &Default::default()).unwrap().unwrap();
     assert_eq!(value, JsonValue::String(Cow::Borrowed("test")));
   }
 
   #[test]
   fn it_should_parse_string_with_quotes() {
-    let value = parse_to_value(r#""echo \"test\"""#).unwrap().unwrap();
+    let value = parse_to_value(r#""echo \"test\"""#, &Default::default())
+      .unwrap()
+      .unwrap();
     assert_eq!(value, JsonValue::String(Cow::Borrowed(r#"echo "test""#)));
   }
 
   #[test]
   fn it_should_parse_array() {
-    let value = parse_to_value(r#"[false, true]"#).unwrap().unwrap();
+    let value = parse_to_value(r#"[false, true]"#, &Default::default())
+      .unwrap()
+      .unwrap();
     assert_eq!(
       value,
       JsonValue::Array(vec![JsonValue::Boolean(false), JsonValue::Boolean(true)].into())
@@ -127,19 +132,21 @@ mod tests {
 
   #[test]
   fn it_should_parse_null() {
-    let value = parse_to_value("null").unwrap().unwrap();
+    let value = parse_to_value("null", &Default::default()).unwrap().unwrap();
     assert_eq!(value, JsonValue::Null);
   }
 
   #[test]
   fn it_should_parse_empty() {
-    let value = parse_to_value("").unwrap();
+    let value = parse_to_value("", &Default::default()).unwrap();
     assert_eq!(value.is_none(), true);
   }
 
   #[test]
   fn error_unexpected_token() {
-    let err = parse_to_value("{\n  \"a\":\u{200b}5 }").err().unwrap();
+    let err = parse_to_value("{\n  \"a\":\u{200b}5 }", &Default::default())
+      .err()
+      .unwrap();
     assert_eq!(err.range.start, 8);
     assert_eq!(err.range.end, 11);
     assert_eq!(err.message, "Unexpected token");

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -18,8 +18,8 @@ const CHAR_BUFFER_MAX_SIZE: usize = 6;
 
 impl<'a> Scanner<'a> {
   /// Creates a new scanner based on the provided text.
-  pub fn new(text: &'a str) -> Scanner<'a> {
-    let mut char_iter = text.chars();
+  pub fn new(file_text: &'a str) -> Scanner<'a> {
+    let mut char_iter = file_text.chars();
     let mut char_buffer = Vec::with_capacity(CHAR_BUFFER_MAX_SIZE);
     let current_char = char_iter.next();
     if let Some(current_char) = current_char {
@@ -32,8 +32,12 @@ impl<'a> Scanner<'a> {
       char_iter,
       char_buffer,
       current_token: None,
-      file_text: text,
+      file_text,
     }
+  }
+
+  pub fn file_text(&self) -> &str {
+    &self.file_text
   }
 
   /// Moves to and returns the next token.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,5 +1,5 @@
 use super::ast::Value as AstValue;
-use super::{errors::ParseError, parse_to_ast, ParseOptions};
+use super::{errors::ParseError, parse_to_ast, CollectOptions, ParseOptions};
 use serde_json::Value as SerdeValue;
 use std::str::FromStr;
 
@@ -16,16 +16,16 @@ use std::str::FromStr;
 /// ```rs
 /// use jsonc_parser::parse_to_serde_value;
 ///
-/// let json_value = parse_to_serde_value(r#"{ "test": 5 } // test"#).unwrap();
+/// let json_value = parse_to_serde_value(r#"{ "test": 5 } // test"#, &Default::default()).unwrap();
 /// ```
-pub fn parse_to_serde_value(text: &str) -> Result<Option<SerdeValue>, ParseError> {
+pub fn parse_to_serde_value(text: &str, parse_options: &ParseOptions) -> Result<Option<SerdeValue>, ParseError> {
   let value = parse_to_ast(
     text,
-    &ParseOptions {
-      collect_comments: false,
-      collect_tokens: false,
-      ..Default::default()
+    &CollectOptions {
+      comments: false,
+      tokens: false,
     },
+    parse_options,
   )?
   .value;
   Ok(value.map(to_serde))

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -22,8 +22,9 @@ pub fn parse_to_serde_value(text: &str) -> Result<Option<SerdeValue>, ParseError
   let value = parse_to_ast(
     text,
     &ParseOptions {
-      comments: false,
-      tokens: false,
+      collect_comments: false,
+      collect_tokens: false,
+      ..Default::default()
     },
   )?
   .value;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -68,7 +68,7 @@ mod tests {
   }
 
   fn assert_has_error(text: &str, message: &str) {
-    let result = parse_to_serde_value(text);
+    let result = parse_to_serde_value(text, &Default::default());
     match result {
       Ok(_) => panic!("Expected error, but did not find one."),
       Err(err) => assert_eq!(err.to_string(), message),
@@ -77,9 +77,11 @@ mod tests {
 
   #[test]
   fn it_should_parse_to_serde_value() {
-    let result =
-      parse_to_serde_value(r#"{ "a": { "a1": 5 }, "b": [0.3e+025], "c": "c1", "d": true, "e": false, "f": null }"#)
-        .unwrap();
+    let result = parse_to_serde_value(
+      r#"{ "a": { "a1": 5 }, "b": [0.3e+025], "c": "c1", "d": true, "e": false, "f": null }"#,
+      &Default::default(),
+    )
+    .unwrap();
 
     let mut expected_value = serde_json::map::Map::new();
     expected_value.insert("a".to_string(), {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,8 +18,9 @@ fn test_specs() {
     let result = parse_to_ast(
       &json_file_text,
       &ParseOptions {
-        tokens: true,
-        comments: true,
+        collect_comments: true,
+        collect_tokens: true,
+        ..Default::default()
       },
     )
     .expect("Expected no error.");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,11 +17,11 @@ fn test_specs() {
       .replace("\r\n", "\n");
     let result = parse_to_ast(
       &json_file_text,
-      &ParseOptions {
-        collect_comments: true,
-        collect_tokens: true,
-        ..Default::default()
+      &CollectOptions {
+        comments: true,
+        tokens: true,
       },
+      &Default::default(),
     )
     .expect("Expected no error.");
     let result_text = parse_result_to_test_str(&result);


### PR DESCRIPTION
To parse strictly as JSON, set all the `allow_*` properties to `false`.