### PR TITLE
feat: add from trait for serde value

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,24 @@ let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &CollectOptions {
 // ...inspect parse_result for value, tokens, and comments here...
 ```
 
-Or use the "serde" feature:
+## Serde
+
+If you enable the `"serde"` feature as follows:
 
 ```toml
 # in Cargo.toml
 jsonc-parser = { version = "...", features = ["serde"] }
 ```
 
+Then you can use the `parse_to_serde_value` function to get a `serde_json::Value`:
+
 ```rs
 use jsonc_parser::parse_to_serde_value;
 
 let json_value = parse_to_serde_value(r#"{ "test": 5 } // test"#, &Default::default())?;
 ```
+
+Alternatively, use `parse_to_ast` then call `.into()` (ex. `let value: serde_json::Value = ast.into();`).
 
 ## Parse Strictly as JSON
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,5 @@
 use super::common::{Range, Ranged};
-use std::{borrow::Cow, str::FromStr};
+use std::borrow::Cow;
 
 /// JSON value.
 #[derive(Debug, PartialEq, Clone)]
@@ -15,6 +15,7 @@ pub enum Value<'a> {
 #[cfg(feature = "serde")]
 impl<'a> From<Value<'a>> for serde_json::Value {
   fn from(value: Value<'a>) -> Self {
+    use std::str::FromStr;
     match value {
       Value::Array(arr) => {
         let vec = arr.elements.into_iter().map(|v| v.into()).collect();
@@ -28,7 +29,7 @@ impl<'a> From<Value<'a>> for serde_json::Value {
       }
       Value::Object(obj) => {
         let mut map = serde_json::map::Map::new();
-        for prop in obj.properties.into_iter() {
+        for prop in obj.properties {
           map.insert(prop.name.into_string(), prop.value.into());
         }
         serde_json::Value::Object(map)
@@ -509,17 +510,25 @@ mod test {
   #[cfg(feature = "serde")]
   #[test]
   fn it_should_coerce_to_serde_value() {
-    let ast = parse_to_ast(r#"{"prop":[true,1,null,"str"]}"#, &Default::default(), &ParseOptions::default()).unwrap();
+    let ast = parse_to_ast(
+      r#"{"prop":[true,1,null,"str"]}"#,
+      &Default::default(),
+      &ParseOptions::default(),
+    )
+    .unwrap();
     let value = ast.value.unwrap();
     let serde_value: serde_json::Value = value.into();
 
-    assert_eq!(serde_value, serde_json::json!({
-      "prop": [
-        true,
-        1,
-        null,
-        "str"
-      ]
-    }));
+    assert_eq!(
+      serde_value,
+      serde_json::json!({
+        "prop": [
+          true,
+          1,
+          null,
+          "str"
+        ]
+      })
+    );
   }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,5 @@
 use super::common::{Range, Ranged};
-use std::borrow::Cow;
+use std::{borrow::Cow, str::FromStr};
 
 /// JSON value.
 #[derive(Debug, PartialEq, Clone)]
@@ -10,6 +10,32 @@ pub enum Value<'a> {
   Object(Object<'a>),
   Array(Array<'a>),
   NullKeyword(NullKeyword),
+}
+
+#[cfg(feature = "serde")]
+impl<'a> From<Value<'a>> for serde_json::Value {
+  fn from(value: Value<'a>) -> Self {
+    match value {
+      Value::Array(arr) => {
+        let vec = arr.elements.into_iter().map(|v| v.into()).collect();
+        serde_json::Value::Array(vec)
+      }
+      Value::BooleanLit(b) => serde_json::Value::Bool(b.value),
+      Value::NullKeyword(_) => serde_json::Value::Null,
+      Value::NumberLit(num) => {
+        let number = serde_json::Number::from_str(num.value).expect("could not parse number");
+        serde_json::Value::Number(number)
+      }
+      Value::Object(obj) => {
+        let mut map = serde_json::map::Map::new();
+        for prop in obj.properties.into_iter() {
+          map.insert(prop.name.into_string(), prop.value.into());
+        }
+        serde_json::Value::Object(map)
+      }
+      Value::StringLit(s) => serde_json::Value::String(s.value.into_owned()),
+    }
+  }
 }
 
 /// Node that can appear in the AST.
@@ -478,5 +504,22 @@ mod test {
     assert_eq!(obj.get_string("prop").is_some(), true);
     assert_eq!(obj.get("asdf"), None);
     assert_eq!(obj.properties.len(), 1);
+  }
+
+  #[cfg(feature = "serde")]
+  #[test]
+  fn it_should_coerce_to_serde_value() {
+    let ast = parse_to_ast(r#"{"prop":[true,1,null,"str"]}"#, &Default::default(), &ParseOptions::default()).unwrap();
+    let value = ast.value.unwrap();
+    let serde_value: serde_json::Value = value.into();
+
+    assert_eq!(serde_value, serde_json::json!({
+      "prop": [
+        true,
+        1,
+        null,
+        "str"
+      ]
+    }));
   }
 }


### PR DESCRIPTION
Closes: #26

A simple `From` trait seems to make it easy to convert an `ast::Value` to a `serde_json::Value`. The `to_serde` does feel a bit redundant now.