### PR TITLE
fix: support parsing exponent without plus or minus sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: 1.58.0
-        override: true
-
+    - uses: dsherret/rust-toolchain-file@v1
     - uses: Swatinem/rust-cache@v1
 
     - name: Build debug

--- a/dprint.json
+++ b/dprint.json
@@ -11,7 +11,7 @@
     "./benches/json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.13.3.wasm",
-    "https://plugins.dprint.dev/exec-0.3.1.json@9351b67ec7a6b58a69201c2834cba38cb3d191080aefc6422fb1320f03c8fc4d"
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+    "https://plugins.dprint.dev/exec-0.3.5.json@d687dda57be0fe9a0088ccdaefa5147649ff24127d8b3ea227536c68ee7abeab"
   ]
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.69.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
For https://github.com/dprint/dprint-plugin-json/issues/16