### PR TITLE
feat: CST and first class manipulation API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,11 @@ jobs:
       RUST_BACKTRACE: full
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: dsherret/rust-toolchain-file@v1
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
-
-    - name: Build debug
-      if: matrix.config.kind == 'test_debug'
-      run: cargo build --verbose
-    - name: Build release
-      if: matrix.config.kind == 'test_release'
-      run: cargo build --release --verbose
 
     - name: Test debug
       if: matrix.config.kind == 'test_debug'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 description = "JSONC parser."
 repository = "https://github.com/dprint/jsonc-parser"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 indexmap = { version = "2.2.6", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ indexmap = { version = "2.0.2", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [features]
-cst = ["serde_json"]
+cst = []
 preserve_order = ["indexmap", "serde_json/preserve_order"]
 serde = ["serde_json"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ indexmap = { version = "2.0.2", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [features]
-cst = []
+cst = ["serde_json"]
 preserve_order = ["indexmap", "serde_json/preserve_order"]
 serde = ["serde_json"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "JSONC parser."
 repository = "https://github.com/dprint/jsonc-parser"
 
 [dependencies]
-indexmap = { version = "2.0.2", optional = true }
+indexmap = { version = "2.2.6", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ indexmap = { version = "2.0.2", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [features]
+cst = []
 preserve_order = ["indexmap", "serde_json/preserve_order"]
 serde = ["serde_json"]
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ let json_text = r#"{
 let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
 let root_obj = node.root_value().unwrap().as_object().unwrap();
 
+root_obj.get("data").unwrap().set_value(value!({
+  "nested": true
+}));
 root_obj.append("new_key", value!([456, 789, false]));
 
 assert_eq!(node.to_string(), r#"{
-  "data": 123,
+  "data": {
+     "nested": true,
+   },
   "new_key": [456, 789, false]
 }"#);
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &CollectOptions {
 // ...inspect parse_result for value, tokens, and comments here...
 ```
 
-Or a CST (when enabling the `cst` feature):
+Or a CST (when enabling the `cst` feature), which provides a first class manipulation API:
 
 ```rs
 use jsonc_parser::cst::CstRootNode;
@@ -40,8 +40,7 @@ let json_text = r#"{
 }"#;
 
 let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
-let root_value = node.root_value().unwrap();
-let root_obj = root_value.as_object().unwrap();
+let root_obj = node.root_value().unwrap().as_object().unwrap();
 
 root_obj.append("new_key", value!([456, 789, false]));
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,24 @@ let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &CollectOptions {
 Or a CST (when enabling the `cst` feature):
 
 ```rs
-use jsonc_parser::cst::RootNode;
+use jsonc_parser::cst::CstRootNode;
+use jsonc_parser::ParseOptions;
+use jsonc_parser::value;
+
+let json_text = r#"{
+  "data": 123
+}"#;
+
+let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
+let root_value = node.root_value().unwrap();
+let root_obj = root_value.as_object().unwrap();
+
+root_obj.append("new_key", value!([456, 789, false]));
+
+assert_eq!(node.to_string(), r#"{
+  "data": 123,
+  "new_key": [456, 789, false]
+}"#);
 ```
 
 ## Serde

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![](https://img.shields.io/crates/v/jsonc-parser.svg)](https://crates.io/crates/jsonc-parser)
 
-JSONC parser implemented in Rust.
+JSONC parsing and manipulation for Rust.
 
-## Example
+## Parsing
 
 To a simple `JsonValue`:
 
@@ -28,7 +28,9 @@ let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &CollectOptions {
 // ...inspect parse_result for value, tokens, and comments here...
 ```
 
-Or a CST (when enabling the `cst` feature), which provides a first class manipulation API:
+## Manipulation (CST)
+
+When enabling the `cst` cargo feature, parsing to a CST provides a first class manipulation API:
 
 ```rs
 use jsonc_parser::cst::CstRootNode;

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ let json_text = r#"{
   "data": 123
 }"#;
 
-let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
-let root_obj = node.root_value().unwrap().as_object().unwrap();
+let root = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
+let root_obj = root.root_value().unwrap().as_object().unwrap();
 
 root_obj.get("data").unwrap().set_value(value!({
   "nested": true
 }));
 root_obj.append("new_key", value!([456, 789, false]));
 
-assert_eq!(node.to_string(), r#"{
+assert_eq!(root.to_string(), r#"{
   "data": {
      "nested": true,
    },

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or a CST (when enabling the `cst` feature), which provides a first class manipul
 ```rs
 use jsonc_parser::cst::CstRootNode;
 use jsonc_parser::ParseOptions;
-use jsonc_parser::value;
+use jsonc_parser::json;
 
 let json_text = r#"{
   // comment
@@ -43,10 +43,10 @@ let json_text = r#"{
 let root = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
 let root_obj = root.root_value().unwrap().as_object().unwrap();
 
-root_obj.get("data").unwrap().set_value(value!({
+root_obj.get("data").unwrap().set_value(json!({
   "nested": true
 }));
-root_obj.append("new_key", value!([456, 789, false]));
+root_obj.append("new_key", json!([456, 789, false]));
 
 assert_eq!(root.to_string(), r#"{
   // comment

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ let parse_result = parse_to_ast(r#"{ "test": 5 } // test"#, &CollectOptions {
 // ...inspect parse_result for value, tokens, and comments here...
 ```
 
+Or a CST (when enabling the `cst` feature):
+
+```rs
+use jsonc_parser::cst::RootNode;
+```
+
 ## Serde
 
 If you enable the `"serde"` feature as follows:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ use jsonc_parser::ParseOptions;
 use jsonc_parser::value;
 
 let json_text = r#"{
+  // comment
   "data": 123
 }"#;
 
@@ -48,9 +49,10 @@ root_obj.get("data").unwrap().set_value(value!({
 root_obj.append("new_key", value!([456, 789, false]));
 
 assert_eq!(root.to_string(), r#"{
+  // comment
   "data": {
-     "nested": true,
-   },
+    "nested": true,
+  },
   "new_key": [456, 789, false]
 }"#);
 ```

--- a/dprint.json
+++ b/dprint.json
@@ -1,5 +1,4 @@
 {
-  "incremental": true,
   "indentWidth": 2,
   "exec": {
     "commands": [{

--- a/dprint.json
+++ b/dprint.json
@@ -13,7 +13,7 @@
     "./benches/json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
-    "https://plugins.dprint.dev/exec-0.4.3.json@42343548b8022c99b1d750be6b894fe6b6c7ee25f72ae9f9082226dd2e515072"
+    "https://plugins.dprint.dev/markdown-0.17.8.wasm",
+    "https://plugins.dprint.dev/exec-0.5.0.json@8d9972eee71fa1590e04873540421f3eda7674d0f1aae3d7c788615e7b7413d0"
   ]
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.81.0"
 components = ["clippy", "rustfmt"]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -586,11 +586,11 @@ mod test {
     assert_eq!(obj.properties.len(), 2);
     assert_eq!(obj.take_number("prop"), None);
     assert_eq!(obj.properties.len(), 2);
-    assert_eq!(obj.take_string("prop").is_some(), true);
+    assert!(obj.take_string("prop").is_some());
     assert_eq!(obj.properties.len(), 1);
     assert_eq!(obj.take("something"), None);
     assert_eq!(obj.properties.len(), 1);
-    assert_eq!(obj.take("other").is_some(), true);
+    assert!(obj.take("other").is_some());
     assert_eq!(obj.properties.len(), 0);
   }
 
@@ -604,7 +604,7 @@ mod test {
 
     assert_eq!(obj.properties.len(), 1);
     assert_eq!(obj.get_string("asdf"), None);
-    assert_eq!(obj.get_string("prop").is_some(), true);
+    assert!(obj.get_string("prop").is_some());
     assert_eq!(obj.get("asdf"), None);
     assert_eq!(obj.properties.len(), 1);
   }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -411,7 +411,7 @@ impl<'a> Comment<'a> {
 }
 
 impl<'a> Ranged for Comment<'a> {
-  fn range(&self) -> &Range {
+  fn range(&self) -> Range {
     match self {
       Comment::Line(line) => line.range(),
       Comment::Block(line) => line.range(),
@@ -445,7 +445,7 @@ impl<'a, 'b> From<&'b ObjectPropName<'a>> for Node<'a, 'b> {
 }
 
 impl<'a> Ranged for ObjectPropName<'a> {
-  fn range(&self) -> &Range {
+  fn range(&self) -> Range {
     match self {
       ObjectPropName::String(lit) => lit.range(),
       ObjectPropName::Word(lit) => lit.range(),
@@ -456,29 +456,29 @@ impl<'a> Ranged for ObjectPropName<'a> {
 // Implement Traits
 
 macro_rules! impl_ranged {
-    ($($node_name:ident),*) => {
-        $(
-            impl Ranged for $node_name {
-                fn range(&self) -> &Range {
-                    &self.range
-                }
-            }
-        )*
-    };
+  ($($node_name:ident),*) => {
+    $(
+      impl Ranged for $node_name {
+        fn range(&self) -> Range {
+            self.range
+        }
+      }
+    )*
+  };
 }
 
 impl_ranged![BooleanLit, NullKeyword];
 
 macro_rules! impl_ranged_lifetime {
-    ($($node_name:ident),*) => {
-        $(
-            impl<'a> Ranged for $node_name<'a> {
-                fn range(&self) -> &Range {
-                    &self.range
-                }
-            }
-        )*
-    };
+  ($($node_name:ident),*) => {
+    $(
+      impl<'a> Ranged for $node_name<'a> {
+        fn range(&self) -> Range {
+            self.range
+        }
+      }
+    )*
+  };
 }
 
 impl_ranged_lifetime![
@@ -493,7 +493,7 @@ impl_ranged_lifetime![
 ];
 
 impl<'a> Ranged for Value<'a> {
-  fn range(&self) -> &Range {
+  fn range(&self) -> Range {
     match self {
       Value::Array(node) => node.range(),
       Value::BooleanLit(node) => node.range(),
@@ -506,7 +506,7 @@ impl<'a> Ranged for Value<'a> {
 }
 
 impl<'a, 'b> Ranged for Node<'a, 'b> {
-  fn range(&self) -> &Range {
+  fn range(&self) -> Range {
     match self {
       Node::StringLit(node) => node.range(),
       Node::NumberLit(node) => node.range(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -18,15 +18,15 @@ impl Range {
 }
 
 impl Ranged for Range {
-  fn range(&self) -> &Range {
-    self
+  fn range(&self) -> Range {
+    *self
   }
 }
 
 /// Represents an object that has a range in the text.
 pub trait Ranged {
   /// Gets the range.
-  fn range(&self) -> &Range;
+  fn range(&self) -> Range;
 
   /// Gets the byte index of the first character in the text.
   fn start(&self) -> usize {

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -119,16 +119,10 @@ macro_rules! impl_container_methods {
         self.0.borrow().value.get(index).cloned()
       }
 
-      // destroying doesn't update the parent so this is not public
-      fn destroy(&self) {
-        self.clear_children();
-      }
-
       pub fn clear_children(&self) {
         let children = std::mem::take(&mut self.0.borrow_mut().value);
         for child in children {
           child.set_parent(None);
-          child.destroy();
         }
       }
     }
@@ -209,13 +203,6 @@ impl CstNode {
         CstLeafNode::Token(_) | CstLeafNode::Whitespace(_) | CstLeafNode::Comment(_) => true,
       },
       CstNode::Container(_) => false,
-    }
-  }
-
-  fn destroy(self) {
-    match self {
-      CstNode::Container(node) => node.destroy(),
-      CstNode::Leaf(node) => node.set_parent(None),
     }
   }
 
@@ -326,15 +313,6 @@ impl CstContainerNode {
       CstContainerNode::Object(n) => n.clear_children(),
       CstContainerNode::ObjectProp(n) => n.clear_children(),
       CstContainerNode::Array(n) => n.clear_children(),
-    }
-  }
-
-  fn destroy(self) {
-    match self {
-      CstContainerNode::Root(n) => n.destroy(),
-      CstContainerNode::Object(n) => n.destroy(),
-      CstContainerNode::ObjectProp(n) => n.destroy(),
-      CstContainerNode::Array(n) => n.destroy(),
     }
   }
 

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1,16 +1,39 @@
+use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt::Display;
+use std::rc::Rc;
 
-use super::common::Range;
 use super::common::Ranged;
 use crate::ast;
 use crate::errors::ParseError;
 use crate::parse_to_ast;
 use crate::ParseOptions;
 
-pub struct CstRootNode {
-  children: Vec<CstNode>,
+macro_rules! create_inner {
+  ($value:expr) => {
+    Rc::new(RefCell::new(CstValueInner {
+      parent: None,
+      value: $value,
+    }))
+  };
 }
+
+#[derive(Clone, Debug)]
+pub struct ParentInfo {
+  pub parent: CstContainerNode,
+  pub child_index: usize,
+}
+
+#[derive(Debug)]
+struct CstValueInner<T> {
+  parent: Option<ParentInfo>,
+  value: T,
+}
+
+type CstChildrenInner = CstValueInner<Vec<CstNode>>;
+
+#[derive(Debug, Clone)]
+pub struct CstRootNode(Rc<RefCell<CstChildrenInner>>);
 
 impl CstRootNode {
   pub fn parse(text: &str, parse_options: &ParseOptions) -> Result<Self, ParseError> {
@@ -32,115 +55,243 @@ impl CstRootNode {
       .build(parse_result.value),
     )
   }
+
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstRootNode {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    for child in &self.children {
+    for child in &self.0.borrow().value {
       write!(f, "{}", child)?;
     }
     Ok(())
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub enum CstNode {
-  StringLit(CstStringLit),
-  NumberLit(CstNumberLit),
-  BooleanLit(CstBooleanLit),
+  Container(CstContainerNode),
+  Leaf(CstLeafNode),
+}
+
+impl CstNode {
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    match self {
+      CstNode::Container(node) => node.parent_info(),
+      CstNode::Leaf(node) => node.parent_info(),
+    }
+  }
+
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    match self {
+      CstNode::Container(node) => node.set_parent(parent),
+      CstNode::Leaf(node) => node.set_parent(parent),
+    }
+  }
+}
+
+impl Display for CstNode {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      CstNode::Container(node) => node.fmt(f),
+      CstNode::Leaf(node) => node.fmt(f),
+    }
+  }
+}
+
+// impl Ranged for CstNode {
+//   fn range(&self) -> Range {
+//     match self {
+//       CstNode::StringLit(node) => node.range,
+//       CstNode::NumberLit(node) => node.range,
+//       CstNode::BooleanLit(node) => node.range,
+//       CstNode::Object(node) => node.range,
+//       CstNode::ObjectProp(node) => node.range,
+//       CstNode::Array(node) => node.range,
+//       CstNode::NullKeyword(node) => node.range,
+//       CstNode::WordLit(node) => node.range,
+//       CstNode::Token(node) => node.range,
+//       CstNode::Whitespace(node) => node.range,
+//       CstNode::Comment(node) => node.range,
+//     }
+//   }
+// }
+
+#[derive(Debug, Clone)]
+pub enum CstContainerNode {
+  Root(CstRootNode),
   Object(CstObject),
   ObjectProp(CstObjectProp),
   Array(CstArray),
+}
+
+impl CstContainerNode {
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    match self {
+      CstContainerNode::Root(node) => node.parent_info(),
+      CstContainerNode::Object(node) => node.parent_info(),
+      CstContainerNode::ObjectProp(node) => node.parent_info(),
+      CstContainerNode::Array(node) => node.parent_info(),
+    }
+  }
+
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    match self {
+      CstContainerNode::Root(node) => node.set_parent(parent),
+      CstContainerNode::Object(node) => node.set_parent(parent),
+      CstContainerNode::ObjectProp(node) => node.set_parent(parent),
+      CstContainerNode::Array(node) => node.set_parent(parent),
+    }
+  }
+}
+
+impl Display for CstContainerNode {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      CstContainerNode::Root(node) => node.fmt(f),
+      CstContainerNode::Object(node) => node.fmt(f),
+      CstContainerNode::ObjectProp(node) => node.fmt(f),
+      CstContainerNode::Array(node) => node.fmt(f),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub enum CstLeafNode {
+  BooleanLit(CstBooleanLit),
   NullKeyword(CstNullKeyword),
+  NumberLit(CstNumberLit),
+  StringLit(CstStringLit),
   WordLit(CstWordLit),
   Token(CstToken),
   Whitespace(CstWhitespace),
   Comment(CstComment),
 }
 
-impl Display for CstNode {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl CstLeafNode {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
     match self {
-      CstNode::StringLit(node) => write!(f, "{}", node),
-      CstNode::NumberLit(node) => write!(f, "{}", node),
-      CstNode::BooleanLit(node) => write!(f, "{}", node),
-      CstNode::Object(node) => write!(f, "{}", node),
-      CstNode::ObjectProp(node) => write!(f, "{}", node),
-      CstNode::Array(node) => write!(f, "{}", node),
-      CstNode::NullKeyword(node) => write!(f, "{}", node),
-      CstNode::WordLit(node) => write!(f, "{}", node),
-      CstNode::Token(node) => write!(f, "{}", node),
-      CstNode::Whitespace(node) => write!(f, "{}", node),
-      CstNode::Comment(node) => write!(f, "{}", node),
+      CstLeafNode::BooleanLit(node) => node.set_parent(parent),
+      CstLeafNode::NullKeyword(node) => node.set_parent(parent),
+      CstLeafNode::NumberLit(node) => node.set_parent(parent),
+      CstLeafNode::StringLit(node) => node.set_parent(parent),
+      CstLeafNode::WordLit(node) => node.set_parent(parent),
+      CstLeafNode::Token(node) => node.set_parent(parent),
+      CstLeafNode::Whitespace(node) => node.set_parent(parent),
+      CstLeafNode::Comment(node) => node.set_parent(parent),
+    }
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    match self {
+      CstLeafNode::BooleanLit(node) => node.parent_info(),
+      CstLeafNode::NullKeyword(node) => node.parent_info(),
+      CstLeafNode::NumberLit(node) => node.parent_info(),
+      CstLeafNode::StringLit(node) => node.parent_info(),
+      CstLeafNode::WordLit(node) => node.parent_info(),
+      CstLeafNode::Token(node) => node.parent_info(),
+      CstLeafNode::Whitespace(node) => node.parent_info(),
+      CstLeafNode::Comment(node) => node.parent_info(),
     }
   }
 }
 
-impl Ranged for CstNode {
-  fn range(&self) -> Range {
+impl Display for CstLeafNode {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
-      CstNode::StringLit(node) => node.range,
-      CstNode::NumberLit(node) => node.range,
-      CstNode::BooleanLit(node) => node.range,
-      CstNode::Object(node) => node.range,
-      CstNode::ObjectProp(node) => node.range,
-      CstNode::Array(node) => node.range,
-      CstNode::NullKeyword(node) => node.range,
-      CstNode::WordLit(node) => node.range,
-      CstNode::Token(node) => node.range,
-      CstNode::Whitespace(node) => node.range,
-      CstNode::Comment(node) => node.range,
+      CstLeafNode::BooleanLit(node) => node.fmt(f),
+      CstLeafNode::NullKeyword(node) => node.fmt(f),
+      CstLeafNode::NumberLit(node) => node.fmt(f),
+      CstLeafNode::StringLit(node) => node.fmt(f),
+      CstLeafNode::WordLit(node) => node.fmt(f),
+      CstLeafNode::Token(node) => node.fmt(f),
+      CstLeafNode::Whitespace(node) => node.fmt(f),
+      CstLeafNode::Comment(node) => node.fmt(f),
     }
   }
 }
 
 /// Node surrounded in double quotes (ex. `"my string"`).
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstStringLit {
-  pub range: Range,
-  pub value: String,
+#[derive(Debug, Clone)]
+pub struct CstStringLit(Rc<RefCell<CstValueInner<String>>>);
+
+impl CstStringLit {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstStringLit {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "\"{}\"", self.value)
+    write!(f, "\"{}\"", self.0.borrow().value.replace("\"", "\\\""))
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstWordLit {
-  pub range: Range,
-  pub value: String,
+#[derive(Debug, Clone)]
+pub struct CstWordLit(Rc<RefCell<CstValueInner<String>>>);
+
+impl CstWordLit {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstWordLit {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.value)
+    write!(f, "{}", self.0.borrow().value)
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstNumberLit {
-  pub range: Range,
-  pub value: String,
+#[derive(Debug, Clone)]
+pub struct CstNumberLit(Rc<RefCell<CstValueInner<String>>>);
+
+impl CstNumberLit {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstNumberLit {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.value)
+    write!(f, "{}", self.0.borrow().value)
   }
 }
 
 /// Represents a boolean (ex. `true` or `false`).
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstBooleanLit {
-  pub range: Range,
-  pub value: bool,
+#[derive(Debug, Clone)]
+pub struct CstBooleanLit(Rc<RefCell<CstValueInner<bool>>>);
+
+impl CstBooleanLit {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstBooleanLit {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    if self.value {
+    if self.0.borrow().value {
       write!(f, "true")
     } else {
       write!(f, "false")
@@ -149,9 +300,17 @@ impl Display for CstBooleanLit {
 }
 
 /// Represents the null keyword (ex. `null`).
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstNullKeyword {
-  pub range: Range,
+#[derive(Debug, Clone)]
+pub struct CstNullKeyword(Rc<RefCell<CstValueInner<()>>>);
+
+impl CstNullKeyword {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstNullKeyword {
@@ -161,30 +320,97 @@ impl Display for CstNullKeyword {
 }
 
 /// Represents an object that may contain properties (ex. `{}`, `{ "prop": 4 }`).
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstObject {
-  pub range: Range,
-  pub children: Vec<CstNode>,
+#[derive(Debug, Clone)]
+pub struct CstObject(Rc<RefCell<CstChildrenInner>>);
+
+impl CstObject {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstObject {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    for child in &self.children {
+    for child in &self.0.borrow().value {
       write!(f, "{}", child)?;
     }
     Ok(())
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstObjectProp {
-  pub range: Range,
-  pub children: Vec<CstNode>,
+#[derive(Debug, Clone)]
+pub struct CstObjectProp(Rc<RefCell<CstChildrenInner>>);
+
+impl CstObjectProp {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
+
+  pub fn name(&self) -> ObjectPropName {
+    for child in &self.0.borrow().value {
+      match child {
+        CstNode::Leaf(CstLeafNode::StringLit(node)) => return ObjectPropName::String(node.clone()),
+        CstNode::Leaf(CstLeafNode::WordLit(node)) => return ObjectPropName::Word(node.clone()),
+        _ => {
+          // someone may have manipulated this object such that this is no longer there
+        }
+      }
+    }
+    // todo(THIS PR): make this return an error when not found
+    unreachable!();
+  }
+
+  pub fn value(&self) -> CstNode {
+    let name = self.name();
+    let parent_info = name.parent_info().unwrap(); // todo(THIS PR): do not unwrap
+    let children = &self.0.borrow().value;
+    let mut children = (&children[parent_info.child_index + 1..]).iter();
+
+    // first, skip over the colon token
+    while let Some(child) = children.next() {
+      if let CstNode::Leaf(CstLeafNode::Token(token)) = child {
+        if token.value() == ':' {
+          break;
+        }
+      }
+    }
+
+    // now find the value
+    while let Some(child) = children.next() {
+      match child {
+        CstNode::Leaf(leaf) => match leaf {
+          CstLeafNode::BooleanLit(_)
+          | CstLeafNode::NullKeyword(_)
+          | CstLeafNode::NumberLit(_)
+          | CstLeafNode::StringLit(_)
+          | CstLeafNode::WordLit(_) => return child.clone(),
+          CstLeafNode::Token(_) | CstLeafNode::Whitespace(_) | CstLeafNode::Comment(_) => {
+            // ignore
+          }
+        },
+        CstNode::Container(container) => match container {
+          CstContainerNode::Object(_) | CstContainerNode::Array(_) => return child.clone(),
+          CstContainerNode::Root(_) | CstContainerNode::ObjectProp(_) => todo!(), // todo(THIS PR): surface error
+        },
+      }
+    }
+
+    // todo(THIS PR): make this return an error when not found
+    unreachable!();
+  }
 }
 
 impl Display for CstObjectProp {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    for child in &self.children {
+    for child in &self.0.borrow().value {
       write!(f, "{}", child)?;
     }
     Ok(())
@@ -192,60 +418,105 @@ impl Display for CstObjectProp {
 }
 
 /// Represents an object property name that may or may not be in quotes.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub enum ObjectPropName {
   String(CstStringLit),
   Word(CstWordLit),
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstArray {
-  pub range: Range,
-  pub children: Vec<CstNode>,
+impl ObjectPropName {
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    match self {
+      ObjectPropName::String(n) => n.parent_info(),
+      ObjectPropName::Word(n) => n.parent_info(),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct CstArray(Rc<RefCell<CstChildrenInner>>);
+
+impl CstArray {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstArray {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    for child in &self.children {
+    for child in &self.0.borrow().value {
       write!(f, "{}", child)?;
     }
     Ok(())
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstToken {
-  pub range: Range,
-  pub char: char,
+#[derive(Debug, Clone)]
+pub struct CstToken(Rc<RefCell<CstValueInner<char>>>);
+
+impl CstToken {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
+
+  pub fn set_value(&self, value: char) {
+    self.0.borrow_mut().value = value;
+  }
+
+  pub fn value(&self) -> char {
+    self.0.borrow().value
+  }
 }
 
 impl Display for CstToken {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.char)
+    write!(f, "{}", self.0.borrow().value)
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstWhitespace {
-  pub range: Range,
-  pub text: String,
+#[derive(Debug, Clone)]
+pub struct CstWhitespace(Rc<RefCell<CstValueInner<String>>>);
+
+impl CstWhitespace {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstWhitespace {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.text)
+    write!(f, "{}", self.0.borrow().value)
   }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct CstComment {
-  pub range: Range,
-  pub text: String,
+#[derive(Debug, Clone)]
+pub struct CstComment(Rc<RefCell<CstValueInner<String>>>);
+
+impl CstComment {
+  fn set_parent(&self, parent: Option<ParentInfo>) {
+    self.0.borrow_mut().parent = parent;
+  }
+
+  pub fn parent_info(&self) -> Option<ParentInfo> {
+    self.0.borrow().parent.clone()
+  }
 }
 
 impl Display for CstComment {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.text)
+    write!(f, "{}", self.0.borrow().value)
   }
 }
 
@@ -256,21 +527,27 @@ struct CstBuilder<'a> {
 
 impl<'a> CstBuilder<'a> {
   pub fn build(&mut self, ast_value: Option<crate::ast::Value<'a>>) -> CstRootNode {
-    let mut root_node = CstRootNode { children: Vec::new() };
+    let root_node = CstContainerNode::Root(CstRootNode(Rc::new(RefCell::new(CstChildrenInner {
+      parent: None,
+      value: Vec::new(),
+    }))));
 
     if let Some(ast_value) = ast_value {
       let range = ast_value.range();
-      self.scan_from_to(0, range.start, &mut root_node.children);
-      root_node.children.push(self.build_value(ast_value));
-      self.scan_from_to(range.end, self.text.len(), &mut root_node.children);
+      self.scan_from_to(&root_node, 0, range.start);
+      self.build_value(&root_node, ast_value);
+      self.scan_from_to(&root_node, range.end, self.text.len());
     } else {
-      self.scan_from_to(0, self.text.len(), &mut root_node.children);
+      self.scan_from_to(&root_node, 0, self.text.len());
     }
 
-    root_node
+    match root_node {
+      CstContainerNode::Root(node) => node,
+      _ => unreachable!(),
+    }
   }
 
-  fn scan_from_to(&mut self, from: usize, to: usize, trivia: &mut Vec<CstNode>) {
+  fn scan_from_to(&mut self, container: &CstContainerNode, from: usize, to: usize) {
     if from == to {
       return;
     }
@@ -281,10 +558,7 @@ impl<'a> CstBuilder<'a> {
         self.tokens.pop_front();
       } else if token.range.start < to {
         if token.range.start > last_from {
-          trivia.push(CstNode::Whitespace(CstWhitespace {
-            range: Range::new(last_from, token.range.start),
-            text: self.text[last_from..token.range.start].to_string(),
-          }));
+          self.build_whitespace(container, self.text[last_from..token.range.start].to_string());
         }
         let token = self.tokens.pop_front().unwrap();
         match token.token {
@@ -294,10 +568,7 @@ impl<'a> CstBuilder<'a> {
           | crate::tokens::Token::CloseBracket
           | crate::tokens::Token::Comma
           | crate::tokens::Token::Colon => {
-            trivia.push(CstNode::Token(CstToken {
-              range: token.range,
-              char: token.token.as_str().chars().next().unwrap(),
-            }));
+            self.build_token(container, token.token.as_str().chars().next().unwrap());
           }
           crate::tokens::Token::Null
           | crate::tokens::Token::String(_)
@@ -305,10 +576,12 @@ impl<'a> CstBuilder<'a> {
           | crate::tokens::Token::Boolean(_)
           | crate::tokens::Token::Number(_) => unreachable!(),
           crate::tokens::Token::CommentLine(_) | crate::tokens::Token::CommentBlock(_) => {
-            trivia.push(CstNode::Comment(CstComment {
-              range: token.range,
-              text: self.text[token.range.start..token.range.end].to_string(),
-            }));
+            self.raw_append_child(
+              container,
+              CstNode::Leaf(CstLeafNode::Comment(CstComment(create_inner!(self.text
+                [token.range.start..token.range.end]
+                .to_string())))),
+            );
           }
         }
         last_from = token.range.end;
@@ -318,87 +591,122 @@ impl<'a> CstBuilder<'a> {
     }
   }
 
-  fn build_value(&mut self, ast_value: ast::Value<'_>) -> CstNode {
+  fn build_value(&mut self, container: &CstContainerNode, ast_value: ast::Value<'_>) {
     match ast_value {
-      ast::Value::StringLit(string_lit) => CstNode::StringLit(self.build_string_lit(string_lit)),
-      ast::Value::NumberLit(number_lit) => CstNode::NumberLit(CstNumberLit {
-        range: number_lit.range,
-        value: number_lit.value.to_string(),
-      }),
-      ast::Value::BooleanLit(boolean_lit) => CstNode::BooleanLit(CstBooleanLit {
-        range: boolean_lit.range,
-        value: boolean_lit.value,
-      }),
-      ast::Value::Object(object) => CstNode::Object(self.build_object(object)),
-      ast::Value::Array(array) => CstNode::Array(self.build_array(array)),
-      ast::Value::NullKeyword(null_keyword) => CstNode::NullKeyword(CstNullKeyword {
-        range: null_keyword.range,
-      }),
+      ast::Value::StringLit(string_lit) => self.build_string_lit(container, string_lit),
+      ast::Value::NumberLit(number_lit) => self.raw_append_child(
+        container,
+        CstNode::Leaf(CstLeafNode::NumberLit(CstNumberLit(create_inner!(number_lit
+          .value
+          .to_string())))),
+      ),
+      ast::Value::BooleanLit(boolean_lit) => self.raw_append_child(
+        container,
+        CstNode::Leaf(CstLeafNode::BooleanLit(CstBooleanLit(create_inner!(boolean_lit.value)))),
+      ),
+      ast::Value::Object(object) => {
+        let object = self.build_object(object);
+        self.raw_append_child(container, CstNode::Container(object))
+      }
+      ast::Value::Array(array) => {
+        let array = self.build_array(array);
+        self.raw_append_child(container, CstNode::Container(array))
+      }
+      ast::Value::NullKeyword(_) => self.raw_append_child(
+        container,
+        CstNode::Leaf(CstLeafNode::NullKeyword(CstNullKeyword(create_inner!(())))),
+      ),
     }
   }
 
-  fn build_object(&mut self, object: ast::Object<'_>) -> CstObject {
+  fn build_object(&mut self, object: ast::Object<'_>) -> CstContainerNode {
+    let container = CstContainerNode::Object(CstObject(create_inner!(Vec::new())));
     let mut last_range_end = object.range.start;
-    let mut children = Vec::new();
     for prop in object.properties {
-      self.scan_from_to(last_range_end, prop.range.start, &mut children);
+      self.scan_from_to(&container, last_range_end, prop.range.start);
       last_range_end = prop.range.end;
-      children.push(CstNode::ObjectProp(self.build_object_prop(prop)));
+      let object_prop = self.build_object_prop(prop);
+      self.raw_append_child(&container, CstNode::Container(object_prop));
     }
-    self.scan_from_to(last_range_end, object.range.end, &mut children);
+    self.scan_from_to(&container, last_range_end, object.range.end);
 
-    CstObject {
-      range: object.range,
-      children,
-    }
+    container
   }
 
-  fn build_object_prop(&mut self, prop: ast::ObjectProp<'_>) -> CstObjectProp {
-    let mut children = Vec::new();
+  fn build_object_prop(&mut self, prop: ast::ObjectProp<'_>) -> CstContainerNode {
+    let container = CstContainerNode::ObjectProp(CstObjectProp(create_inner!(Vec::new())));
     let name_range = prop.name.range();
     let value_range = prop.value.range();
 
     match prop.name {
       ast::ObjectPropName::String(string_lit) => {
-        children.push(CstNode::StringLit(self.build_string_lit(string_lit)));
+        self.build_string_lit(&container, string_lit);
       }
       ast::ObjectPropName::Word(word_lit) => {
-        children.push(CstNode::WordLit(CstWordLit {
-          range: word_lit.range,
-          value: word_lit.value.to_string(),
-        }));
+        self.raw_append_child(
+          &container,
+          CstNode::Leaf(CstLeafNode::WordLit(CstWordLit(create_inner!(word_lit
+            .value
+            .to_string())))),
+        );
       }
     }
-    self.scan_from_to(name_range.end, value_range.start, &mut children);
-    children.push(self.build_value(prop.value));
+    self.scan_from_to(&container, name_range.end, value_range.start);
+    self.build_value(&container, prop.value);
 
-    CstObjectProp {
-      range: prop.range,
-      children,
-    }
+    container
   }
 
-  fn build_string_lit(&mut self, string_lit: ast::StringLit<'_>) -> CstStringLit {
-    CstStringLit {
-      range: string_lit.range,
-      value: string_lit.value.into_owned(),
-    }
+  fn build_token(&self, container: &CstContainerNode, value: char) {
+    self.raw_append_child(
+      container,
+      CstNode::Leaf(CstLeafNode::Token(CstToken(create_inner!(value)))),
+    );
   }
 
-  fn build_array(&mut self, array: ast::Array<'_>) -> CstArray {
+  fn build_whitespace(&self, container: &CstContainerNode, value: String) {
+    self.raw_append_child(
+      container,
+      CstNode::Leaf(CstLeafNode::Whitespace(CstWhitespace(create_inner!(value)))),
+    );
+  }
+
+  fn build_string_lit(&self, container: &CstContainerNode, lit: ast::StringLit<'_>) {
+    self.raw_append_child(
+      container,
+      CstNode::Leaf(CstLeafNode::StringLit(CstStringLit(create_inner!(lit
+        .value
+        .into_owned())))),
+    );
+  }
+
+  fn build_array(&mut self, array: ast::Array<'_>) -> CstContainerNode {
+    let container = CstContainerNode::Array(CstArray(create_inner!(Vec::new())));
     let mut last_range_end = array.range.start;
-    let mut children = Vec::new();
     for element in array.elements {
       let element_range = element.range();
-      self.scan_from_to(last_range_end, element_range.start, &mut children);
-      children.push(self.build_value(element));
+      self.scan_from_to(&container, last_range_end, element_range.start);
+      self.build_value(&container, element);
       last_range_end = element_range.end;
     }
-    self.scan_from_to(last_range_end, array.range.end, &mut children);
+    self.scan_from_to(&container, last_range_end, array.range.end);
 
-    CstArray {
-      range: array.range,
-      children,
-    }
+    container
+  }
+
+  fn raw_append_child(&self, container: &CstContainerNode, child: CstNode) {
+    let cloned_self = container.clone();
+    let mut container = match container {
+      CstContainerNode::Root(node) => node.0.borrow_mut(),
+      CstContainerNode::Object(node) => node.0.borrow_mut(),
+      CstContainerNode::ObjectProp(node) => node.0.borrow_mut(),
+      CstContainerNode::Array(node) => node.0.borrow_mut(),
+    };
+    let parent_info = ParentInfo {
+      parent: cloned_self,
+      child_index: container.value.len(),
+    };
+    child.set_parent(Some(parent_info));
+    container.value.push(child);
   }
 }

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -466,7 +466,7 @@ impl CstRootNode {
   /// Computes the single indentation text of the file.
   pub fn single_indent_text(&self) -> Option<String> {
     let root_value = self.root_value()?;
-    let first_non_trivia_child = root_value.children_exclude_trivia().get(0)?.clone();
+    let first_non_trivia_child = root_value.children_exclude_trivia().first()?.clone();
     let mut looking_node = first_non_trivia_child;
     while let Some(previous_trivia) = looking_node.previous_sibling() {
       if let CstNode::Leaf(CstLeafNode::Whitespace(whitespace)) = &previous_trivia {
@@ -618,10 +618,10 @@ impl CstObjectProp {
     let name = self.name()?;
     let parent_info = name.parent_info().unwrap(); // todo(THIS PR): do not unwrap
     let children = &self.0.borrow().value;
-    let mut children = (&children[parent_info.child_index + 1..]).iter();
+    let mut children = children[parent_info.child_index + 1..].iter();
 
     // first, skip over the colon token
-    while let Some(child) = children.next() {
+    for child in children.by_ref() {
       if let CstNode::Leaf(CstLeafNode::Token(token)) = child {
         if token.value() == ':' {
           break;
@@ -630,7 +630,7 @@ impl CstObjectProp {
     }
 
     // now find the value
-    while let Some(child) = children.next() {
+    for child in children {
       match child {
         CstNode::Leaf(leaf) => match leaf {
           CstLeafNode::BooleanLit(_)

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1,0 +1,297 @@
+use std::collections::VecDeque;
+
+use super::common::Range;
+use super::common::Ranged;
+use crate::ast;
+use crate::errors::ParseError;
+use crate::parse_to_ast;
+use crate::ParseOptions;
+
+pub struct CstRootNode {
+  children: Vec<CstNode>,
+}
+
+impl CstRootNode {
+  pub fn parse(text: &str, parse_options: &ParseOptions) -> Result<Self, ParseError> {
+    let parse_result = parse_to_ast(
+      text,
+      &crate::CollectOptions {
+        comments: crate::CommentCollectionStrategy::AsTokens,
+        tokens: true,
+      },
+      parse_options,
+    )?;
+
+    // turn the AST into a CST
+    Ok(
+      CstBuilder {
+        text,
+        tokens: parse_result.tokens.unwrap().into_iter().collect(),
+      }
+      .build(parse_result.value),
+    )
+  }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum CstNode {
+  StringLit(CstStringLit),
+  NumberLit(CstNumberLit),
+  BooleanLit(CstBooleanLit),
+  Object(CstObject),
+  ObjectProp(CstObjectProp),
+  Array(CstArray),
+  NullKeyword(CstNullKeyword),
+  WordLit(CstWordLit),
+  Token(CstToken),
+  Whitespace(Whitespace),
+  Comment(CstComment),
+}
+
+impl Ranged for CstNode {
+  fn range(&self) -> Range {
+    match self {
+      CstNode::StringLit(node) => node.range,
+      CstNode::NumberLit(node) => node.range,
+      CstNode::BooleanLit(node) => node.range,
+      CstNode::Object(node) => node.range,
+      CstNode::ObjectProp(node) => node.range,
+      CstNode::Array(node) => node.range,
+      CstNode::NullKeyword(node) => node.range,
+      CstNode::WordLit(node) => node.range,
+      CstNode::Token(node) => node.range,
+      CstNode::Whitespace(node) => node.range,
+      CstNode::Comment(node) => node.range,
+    }
+  }
+}
+
+/// Node surrounded in double quotes (ex. `"my string"`).
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstStringLit {
+  pub range: Range,
+  pub value: String,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstWordLit {
+  pub range: Range,
+  pub value: String,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstNumberLit {
+  pub range: Range,
+  pub value: String,
+}
+
+/// Represents a boolean (ex. `true` or `false`).
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstBooleanLit {
+  pub range: Range,
+  pub value: bool,
+}
+
+/// Represents the null keyword (ex. `null`).
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstNullKeyword {
+  pub range: Range,
+}
+
+/// Represents an object that may contain properties (ex. `{}`, `{ "prop": 4 }`).
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstObject {
+  pub range: Range,
+  pub children: Vec<CstNode>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstObjectProp {
+  pub range: Range,
+  pub children: Vec<CstNode>,
+}
+
+/// Represents an object property name that may or may not be in quotes.
+#[derive(Debug, PartialEq, Clone)]
+pub enum ObjectPropName {
+  String(CstStringLit),
+  Word(CstWordLit),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstArray {
+  pub range: Range,
+  pub children: Vec<CstNode>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstToken {
+  pub range: Range,
+  pub char: char,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Whitespace {
+  pub range: Range,
+  pub text: String,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CstComment {
+  pub range: Range,
+  pub text: String,
+}
+
+struct CstBuilder<'a> {
+  pub text: &'a str,
+  pub tokens: VecDeque<crate::tokens::TokenAndRange<'a>>,
+}
+
+impl<'a> CstBuilder<'a> {
+  pub fn build(&mut self, ast_value: Option<crate::ast::Value<'a>>) -> CstRootNode {
+    let mut root_node = CstRootNode { children: Vec::new() };
+
+    if let Some(ast_value) = ast_value {
+      let range = ast_value.range();
+      self.scan_from_to(0, range.start, &mut root_node.children);
+      root_node.children.push(self.build_value(ast_value));
+      self.scan_from_to(range.end, self.text.len(), &mut root_node.children);
+    } else {
+      self.scan_from_to(0, self.text.len(), &mut root_node.children);
+    }
+
+    root_node
+  }
+
+  fn scan_from_to(&mut self, from: usize, to: usize, trivia: &mut Vec<CstNode>) {
+    if from == to {
+      return;
+    }
+
+    let mut last_from = from;
+    while let Some(token) = self.tokens.front() {
+      if token.range.end < from {
+        self.tokens.pop_front();
+      } else if token.range.start < to {
+        if token.range.start > last_from {
+          trivia.push(CstNode::Whitespace(Whitespace {
+            range: Range::new(last_from, token.range.start),
+            text: self.text[last_from..token.range.start].to_string(),
+          }));
+        }
+        let token = self.tokens.pop_front().unwrap();
+        match token.token {
+          crate::tokens::Token::OpenBrace
+          | crate::tokens::Token::CloseBrace
+          | crate::tokens::Token::OpenBracket
+          | crate::tokens::Token::CloseBracket
+          | crate::tokens::Token::Comma
+          | crate::tokens::Token::Colon => {
+            trivia.push(CstNode::Token(CstToken {
+              range: token.range,
+              char: token.token.as_str().chars().next().unwrap(),
+            }));
+          }
+          crate::tokens::Token::Null
+          | crate::tokens::Token::String(_)
+          | crate::tokens::Token::Word(_)
+          | crate::tokens::Token::Boolean(_)
+          | crate::tokens::Token::Number(_) => unreachable!(),
+          crate::tokens::Token::CommentLine(_) | crate::tokens::Token::CommentBlock(_) => {
+            trivia.push(CstNode::Comment(CstComment {
+              range: token.range,
+              text: self.text[token.range.start..token.range.end].to_string(),
+            }));
+          }
+        }
+        last_from = token.range.end;
+      } else {
+        break;
+      }
+    }
+  }
+
+  fn build_value(&mut self, ast_value: ast::Value<'_>) -> CstNode {
+    match ast_value {
+      ast::Value::StringLit(string_lit) => CstNode::StringLit(self.build_string_lit(string_lit)),
+      ast::Value::NumberLit(number_lit) => CstNode::NumberLit(CstNumberLit {
+        range: number_lit.range,
+        value: number_lit.value.to_string(),
+      }),
+      ast::Value::BooleanLit(boolean_lit) => CstNode::BooleanLit(CstBooleanLit {
+        range: boolean_lit.range,
+        value: boolean_lit.value,
+      }),
+      ast::Value::Object(object) => CstNode::Object(self.build_object(object)),
+      ast::Value::Array(array) => CstNode::Array(self.build_array(array)),
+      ast::Value::NullKeyword(null_keyword) => CstNode::NullKeyword(CstNullKeyword {
+        range: null_keyword.range,
+      }),
+    }
+  }
+
+  fn build_object(&mut self, object: ast::Object<'_>) -> CstObject {
+    let mut last_range_end = object.range.start;
+    let mut children = Vec::new();
+    for prop in object.properties {
+      self.scan_from_to(last_range_end, prop.range.start, &mut children);
+      last_range_end = prop.range.end;
+      children.push(CstNode::ObjectProp(self.build_object_prop(prop)));
+    }
+    self.scan_from_to(last_range_end, object.range.end, &mut children);
+
+    CstObject {
+      range: object.range,
+      children,
+    }
+  }
+
+  fn build_object_prop(&mut self, prop: ast::ObjectProp<'_>) -> CstObjectProp {
+    let mut children = Vec::new();
+    let name_range = prop.name.range();
+    let value_range = prop.value.range();
+
+    match prop.name {
+      ast::ObjectPropName::String(string_lit) => {
+        children.push(CstNode::StringLit(self.build_string_lit(string_lit)));
+      }
+      ast::ObjectPropName::Word(word_lit) => {
+        children.push(CstNode::WordLit(CstWordLit {
+          range: word_lit.range,
+          value: word_lit.value.to_string(),
+        }));
+      }
+    }
+    self.scan_from_to(name_range.end, value_range.start, &mut children);
+    children.push(self.build_value(prop.value));
+
+    CstObjectProp {
+      range: prop.range,
+      children,
+    }
+  }
+
+  fn build_string_lit(&mut self, string_lit: ast::StringLit<'_>) -> CstStringLit {
+    CstStringLit {
+      range: string_lit.range,
+      value: string_lit.value.into_owned(),
+    }
+  }
+
+  fn build_array(&mut self, array: ast::Array<'_>) -> CstArray {
+    let mut last_range_end = array.range.start;
+    let mut children = Vec::new();
+    for element in array.elements {
+      let element_range = element.range();
+      self.scan_from_to(last_range_end, element_range.start, &mut children);
+      children.push(self.build_value(element));
+      last_range_end = element_range.end;
+    }
+    self.scan_from_to(last_range_end, array.range.end, &mut children);
+
+    CstArray {
+      range: array.range,
+      children,
+    }
+  }
+}

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -14,16 +14,16 @@ impl RawCstValue {
   pub(crate) fn force_multiline(&self) -> bool {
     match self {
       RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
-      RawCstValue::Array(v) => v.iter().any(|v| v.is_object_or_array()),
-      RawCstValue::Object(v) => v.len() > 0,
+      RawCstValue::Array(v) => v.iter().any(|v| v.is_object_or_array_with_elements()),
+      RawCstValue::Object(v) => !v.is_empty(),
     }
   }
 
-  fn is_object_or_array(&self) -> bool {
+  fn is_object_or_array_with_elements(&self) -> bool {
     match self {
       RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
-      RawCstValue::Array(_) => true,
-      RawCstValue::Object(_) => false,
+      RawCstValue::Array(v) => !v.is_empty(),
+      RawCstValue::Object(v) => !v.is_empty(),
     }
   }
 }

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -1,0 +1,27 @@
+// todo: write a json! macro for creating one of these easily... it's much more difficult than it seems
+
+#[derive(Debug, Clone)]
+pub enum RawCstValue {
+  Null,
+  Bool(bool),
+  Number(String),
+  String(String),
+  Array(Vec<RawCstValue>),
+  Object(Vec<RawCstObjectValue>),
+  Comment(String),
+}
+
+impl RawCstValue {
+  pub(crate) fn force_multiline(&self) -> bool {
+    match self {
+      RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
+      RawCstValue::Array(_) | RawCstValue::Object(_) | RawCstValue::Comment(_) => true,
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub enum RawCstObjectValue {
+  Comment(String),
+  KeyValue(String, RawCstValue),
+}

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -27,7 +27,7 @@ impl RawCstValue {
 }
 
 #[macro_export]
-macro_rules! json {
+macro_rules! cst_value {
   (null) => {
     $crate::cst::RawCstValue::Null
   };
@@ -50,13 +50,13 @@ macro_rules! json {
 
   ([ $($elems:tt),* $(,)? ]) => {
     $crate::cst::RawCstValue::Array(vec![
-      $(json!($elems)),*
+      $(cst_value!($elems)),*
     ])
   };
 
   ({ $($key:tt : $value:tt),* $(,)? }) => {
     $crate::cst::RawCstValue::Object(vec![
-      $(($key.to_string(), json!($value))),*
+      $(($key.to_string(), cst_value!($value))),*
     ])
   };
 }

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -1,62 +1,62 @@
 #[derive(Debug, Clone)]
-pub enum RawCstValue {
+pub enum CstInputValue {
   Null,
   Bool(bool),
   Number(String),
   String(String),
-  Array(Vec<RawCstValue>),
-  Object(Vec<(String, RawCstValue)>),
+  Array(Vec<CstInputValue>),
+  Object(Vec<(String, CstInputValue)>),
 }
 
-impl RawCstValue {
+impl CstInputValue {
   pub(crate) fn force_multiline(&self) -> bool {
     match self {
-      RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
-      RawCstValue::Array(v) => v.iter().any(|v| v.is_object_or_array_with_elements()),
-      RawCstValue::Object(v) => !v.is_empty(),
+      CstInputValue::Null | CstInputValue::Bool(_) | CstInputValue::Number(_) | CstInputValue::String(_) => false,
+      CstInputValue::Array(v) => v.iter().any(|v| v.is_object_or_array_with_elements()),
+      CstInputValue::Object(v) => !v.is_empty(),
     }
   }
 
   fn is_object_or_array_with_elements(&self) -> bool {
     match self {
-      RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
-      RawCstValue::Array(v) => !v.is_empty(),
-      RawCstValue::Object(v) => !v.is_empty(),
+      CstInputValue::Null | CstInputValue::Bool(_) | CstInputValue::Number(_) | CstInputValue::String(_) => false,
+      CstInputValue::Array(v) => !v.is_empty(),
+      CstInputValue::Object(v) => !v.is_empty(),
     }
   }
 }
 
 #[macro_export]
-macro_rules! cst_value {
+macro_rules! value {
   (null) => {
-    $crate::cst::RawCstValue::Null
+    $crate::cst::CstInputValue::Null
   };
 
   (true) => {
-    $crate::cst::RawCstValue::Bool(true)
+    $crate::cst::CstInputValue::Bool(true)
   };
 
   (false) => {
-    $crate::cst::RawCstValue::Bool(false)
+    $crate::cst::CstInputValue::Bool(false)
   };
 
   ($num:literal) => {
-    $crate::cst::RawCstValue::Number($num.to_string())
+    $crate::cst::CstInputValue::Number($num.to_string())
   };
 
   ($str:literal) => {
-    $crate::cst::RawCstValue::String($str.to_string())
+    $crate::cst::CstInputValue::String($str.to_string())
   };
 
   ([ $($elems:tt),* $(,)? ]) => {
-    $crate::cst::RawCstValue::Array(vec![
-      $(cst_value!($elems)),*
+    $crate::cst::CstInputValue::Array(vec![
+      $(value!($elems)),*
     ])
   };
 
   ({ $($key:tt : $value:tt),* $(,)? }) => {
-    $crate::cst::RawCstValue::Object(vec![
-      $(($key.to_string(), cst_value!($value))),*
+    $crate::cst::CstInputValue::Object(vec![
+      $(($key.to_string(), value!($value))),*
     ])
   };
 }

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -1,5 +1,3 @@
-// todo: write a json! macro for creating one of these easily... it's much more difficult than it seems
-
 #[derive(Debug, Clone)]
 pub enum RawCstValue {
   Null,
@@ -26,4 +24,39 @@ impl RawCstValue {
       RawCstValue::Object(v) => !v.is_empty(),
     }
   }
+}
+
+#[macro_export]
+macro_rules! json {
+  (null) => {
+    $crate::cst::RawCstValue::Null
+  };
+
+  (true) => {
+    $crate::cst::RawCstValue::Bool(true)
+  };
+
+  (false) => {
+    $crate::cst::RawCstValue::Bool(false)
+  };
+
+  ($num:literal) => {
+    $crate::cst::RawCstValue::Number($num.to_string())
+  };
+
+  ($str:literal) => {
+    $crate::cst::RawCstValue::String($str.to_string())
+  };
+
+  ([ $($elems:tt),* $(,)? ]) => {
+    $crate::cst::RawCstValue::Array(vec![
+      $(json!($elems)),*
+    ])
+  };
+
+  ({ $($key:tt : $value:tt),* $(,)? }) => {
+    $crate::cst::RawCstValue::Object(vec![
+      $(($key.to_string(), json!($value))),*
+    ])
+  };
 }

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -27,7 +27,7 @@ impl CstInputValue {
 }
 
 #[macro_export]
-macro_rules! value {
+macro_rules! json {
   (null) => {
     $crate::cst::CstInputValue::Null
   };
@@ -50,13 +50,13 @@ macro_rules! value {
 
   ([ $($elems:tt),* $(,)? ]) => {
     $crate::cst::CstInputValue::Array(vec![
-      $(value!($elems)),*
+      $(json!($elems)),*
     ])
   };
 
   ({ $($key:tt : $value:tt),* $(,)? }) => {
     $crate::cst::CstInputValue::Object(vec![
-      $(($key.to_string(), value!($value))),*
+      $(($key.to_string(), json!($value))),*
     ])
   };
 }

--- a/src/cst/input.rs
+++ b/src/cst/input.rs
@@ -7,21 +7,23 @@ pub enum RawCstValue {
   Number(String),
   String(String),
   Array(Vec<RawCstValue>),
-  Object(Vec<RawCstObjectValue>),
-  Comment(String),
+  Object(Vec<(String, RawCstValue)>),
 }
 
 impl RawCstValue {
   pub(crate) fn force_multiline(&self) -> bool {
     match self {
       RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
-      RawCstValue::Array(_) | RawCstValue::Object(_) | RawCstValue::Comment(_) => true,
+      RawCstValue::Array(v) => v.iter().any(|v| v.is_object_or_array()),
+      RawCstValue::Object(v) => v.len() > 0,
     }
   }
-}
 
-#[derive(Debug, Clone)]
-pub enum RawCstObjectValue {
-  Comment(String),
-  KeyValue(String, RawCstValue),
+  fn is_object_or_array(&self) -> bool {
+    match self {
+      RawCstValue::Null | RawCstValue::Bool(_) | RawCstValue::Number(_) | RawCstValue::String(_) => false,
+      RawCstValue::Array(_) => true,
+      RawCstValue::Object(_) => false,
+    }
+  }
 }

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -713,7 +713,45 @@ impl CstContainerNode {
         }
         array_node.raw_insert_child(index, CstToken::new(']').into());
       }
-      RawCstValue::Object(vec) => {}
+      RawCstValue::Object(elements) => {
+        let object_node: CstContainerNode = CstObject::new().into();
+        self.raw_insert_child(insert_index, object_node.clone().into());
+
+        let mut index = 0;
+        object_node.raw_insert_child(index, CstToken::new('{').into());
+        index += 1;
+        let mut elements = elements.into_iter().peekable();
+        while let Some((prop_name, value)) = elements.next() {
+          if multiline {
+            object_node.raw_insert_child(index, CstNewline::new(newline_kind).into());
+            index += 1;
+            object_node.raw_insert_child(index, CstWhitespace::new(indents.child_indent.clone()).into());
+            index += 1;
+          }
+          object_node.raw_insert_child(index, CstStringLit::new(prop_name).into());
+          index += 1;
+          object_node.raw_insert_child(index, CstToken::new(':').into());
+          index += 1;
+          if multiline {
+            object_node.raw_insert_child(index, CstWhitespace::new(indents.child_indent.clone()).into());
+            index += 1;
+          }
+          object_node.raw_insert_value_with_internal_indent(index, value, newline_kind, indents.indent());
+          index += 1;
+          // todo(dsherret): detect if the file uses trailing commas
+          if elements.peek().is_some() {
+            object_node.raw_insert_child(index, CstToken::new(',').into());
+            index += 1;
+          }
+        }
+        if multiline {
+          object_node.raw_insert_child(index, CstNewline::new(newline_kind).into());
+          index += 1;
+          object_node.raw_insert_child(index, CstWhitespace::new(indents.child_indent).into());
+          index += 1;
+        }
+        object_node.raw_insert_child(index, CstToken::new('}').into());
+      }
     }
   }
 }

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -2116,11 +2116,15 @@ fn trim_inner_start_and_end_blanklines(node: &CstContainerNode) {
       }
     }
 
+    let mut pending = Vec::new();
     while let Some(child) = children.next() {
-      if child.is_whitespace() && children.peek().map(|c| c.is_newline()).unwrap_or(false) {
-        child.remove();
+      if child.is_whitespace() {
+        pending.push(child);
       } else if child.is_newline() {
         child.remove();
+        for child in pending.drain(..) {
+          child.remove();
+        }
       } else {
         break;
       }

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -1478,7 +1478,7 @@ impl CstArray {
 
         // consume the next tokens until the next comma
         let mut trailing_whitespace = Vec::new();
-        while let Some(next_child) = children.next() {
+        for next_child in children.by_ref() {
           if next_child.is_whitespace() {
             trailing_whitespace.push(next_child);
           } else {
@@ -2106,7 +2106,7 @@ fn insert_or_append_to_container(
 fn trim_inner_start_and_end_blanklines(node: &CstContainerNode) {
   fn remove_blank_lines_after_first(children: &mut Peekable<impl Iterator<Item = CstNode>>) {
     // try to find the first newline
-    while let Some(child) = children.next() {
+    for child in children.by_ref() {
       if child.is_whitespace() {
         // keep searching
       } else if child.is_newline() {
@@ -2117,7 +2117,7 @@ fn trim_inner_start_and_end_blanklines(node: &CstContainerNode) {
     }
 
     let mut pending = Vec::new();
-    while let Some(child) = children.next() {
+    for child in children.by_ref() {
       if child.is_whitespace() {
         pending.push(child);
       } else if child.is_newline() {

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -968,6 +968,7 @@ impl CstRootNode {
   /// let json_text = r#"{
   ///   "data": 123
   /// }"#;
+  ///
   /// let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
   /// let root_value = node.root_value().unwrap();
   /// let root_obj = root_value.as_object().unwrap();

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -970,13 +970,13 @@ impl CstRootNode {
   ///   "data": 123
   /// }"#;
   ///
-  /// let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
-  /// let root_obj = node.root_value().unwrap().as_object().unwrap();
+  /// let root = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
+  /// let root_obj = root.root_value().unwrap().as_object().unwrap();
   ///
   /// root_obj.get("data").unwrap().set_value(value!({}));
   /// root_obj.append("new_key", value!([456, 789, false]));
   ///
-  /// assert_eq!(node.to_string(), r#"{
+  /// assert_eq!(root.to_string(), r#"{
   ///   "data": {},
   ///   "new_key": [456, 789, false]
   /// }"#);

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -2457,10 +2457,8 @@ fn set_trailing_commas(
           let mut insert_index = element.child_index() + 1;
           parent.raw_insert_child(Some(&mut insert_index), CstToken::new(',').into());
         }
-      } else {
-        if let Some(trailing_comma) = element.trailing_comma() {
-          trailing_comma.remove();
-        }
+      } else if let Some(trailing_comma) = element.trailing_comma() {
+        trailing_comma.remove();
       }
     }
 

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -307,10 +307,7 @@ impl CstNode {
   }
 
   pub fn is_newline(&self) -> bool {
-    match self {
-      CstNode::Leaf(CstLeafNode::Newline(_)) => true,
-      _ => false,
-    }
+    matches!(self, CstNode::Leaf(CstLeafNode::Newline(_)))
   }
 
   pub fn is_comma(&self) -> bool {
@@ -321,24 +318,15 @@ impl CstNode {
   }
 
   pub fn is_comment(&self) -> bool {
-    match self {
-      CstNode::Leaf(CstLeafNode::Comment(_)) => true,
-      _ => false,
-    }
+    matches!(self, CstNode::Leaf(CstLeafNode::Comment(_)))
   }
 
   pub fn is_token(&self) -> bool {
-    match self {
-      CstNode::Leaf(CstLeafNode::Token(_)) => true,
-      _ => false,
-    }
+    matches!(self, CstNode::Leaf(CstLeafNode::Token(_)))
   }
 
   pub fn is_whitespace(&self) -> bool {
-    match self {
-      CstNode::Leaf(CstLeafNode::Whitespace(_)) => true,
-      _ => false,
-    }
+    matches!(self, CstNode::Leaf(CstLeafNode::Whitespace(_)))
   }
 
   pub fn children(&self) -> Vec<CstNode> {

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -967,17 +967,23 @@ impl CstRootNode {
   /// use jsonc_parser::value;
   ///
   /// let json_text = r#"{
+  ///    // comment
   ///   "data": 123
   /// }"#;
   ///
   /// let root = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
   /// let root_obj = root.root_value().unwrap().as_object().unwrap();
   ///
-  /// root_obj.get("data").unwrap().set_value(value!({}));
+  /// root_obj.get("data").unwrap().set_value(value!({
+  ///   "nested": true
+  /// }));
   /// root_obj.append("new_key", value!([456, 789, false]));
   ///
   /// assert_eq!(root.to_string(), r#"{
-  ///   "data": {},
+  ///    // comment
+  ///   "data": {
+  ///     "nested": true
+  ///   },
   ///   "new_key": [456, 789, false]
   /// }"#);
   /// ```

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -397,105 +397,106 @@ impl CstNode {
   }
 
   /// Node if it's the root node.
-  pub fn as_root_node(&self) -> Option<&CstRootNode> {
+  pub fn as_root_node(&self) -> Option<CstRootNode> {
     match self {
-      CstNode::Container(CstContainerNode::Root(node)) => Some(node),
+      CstNode::Container(CstContainerNode::Root(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's an object.
-  pub fn as_object(&self) -> Option<&CstObject> {
+  pub fn as_object(&self) -> Option<CstObject> {
     match self {
-      CstNode::Container(CstContainerNode::Object(node)) => Some(node),
+      // doesn't return a reference so this is easier to use
+      CstNode::Container(CstContainerNode::Object(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's an array.
-  pub fn as_array(&self) -> Option<&CstArray> {
+  pub fn as_array(&self) -> Option<CstArray> {
     match self {
-      CstNode::Container(CstContainerNode::Array(node)) => Some(node),
+      CstNode::Container(CstContainerNode::Array(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's an object property.
-  pub fn as_object_prop(&self) -> Option<&CstObjectProp> {
+  pub fn as_object_prop(&self) -> Option<CstObjectProp> {
     match self {
-      CstNode::Container(CstContainerNode::ObjectProp(node)) => Some(node),
+      CstNode::Container(CstContainerNode::ObjectProp(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a boolean literal.
-  pub fn as_boolean_lit(&self) -> Option<&CstBooleanLit> {
+  pub fn as_boolean_lit(&self) -> Option<CstBooleanLit> {
     match self {
-      CstNode::Leaf(CstLeafNode::BooleanLit(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::BooleanLit(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a null keyword.
-  pub fn as_null_keyword(&self) -> Option<&CstNullKeyword> {
+  pub fn as_null_keyword(&self) -> Option<CstNullKeyword> {
     match self {
-      CstNode::Leaf(CstLeafNode::NullKeyword(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::NullKeyword(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a number literal.
-  pub fn as_number_lit(&self) -> Option<&CstNumberLit> {
+  pub fn as_number_lit(&self) -> Option<CstNumberLit> {
     match self {
-      CstNode::Leaf(CstLeafNode::NumberLit(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::NumberLit(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a string literal.
-  pub fn as_string_lit(&self) -> Option<&CstStringLit> {
+  pub fn as_string_lit(&self) -> Option<CstStringLit> {
     match self {
-      CstNode::Leaf(CstLeafNode::StringLit(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::StringLit(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a word literal.
-  pub fn as_word_lit(&self) -> Option<&CstWordLit> {
+  pub fn as_word_lit(&self) -> Option<CstWordLit> {
     match self {
-      CstNode::Leaf(CstLeafNode::WordLit(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::WordLit(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a token.
-  pub fn as_token(&self) -> Option<&CstToken> {
+  pub fn as_token(&self) -> Option<CstToken> {
     match self {
-      CstNode::Leaf(CstLeafNode::Token(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::Token(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a newline.
-  pub fn as_newline(&self) -> Option<&CstNewline> {
+  pub fn as_newline(&self) -> Option<CstNewline> {
     match self {
-      CstNode::Leaf(CstLeafNode::Newline(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::Newline(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's whitespace.
-  pub fn as_whitespace(&self) -> Option<&CstWhitespace> {
+  pub fn as_whitespace(&self) -> Option<CstWhitespace> {
     match self {
-      CstNode::Leaf(CstLeafNode::Whitespace(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::Whitespace(node)) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's a comment.
-  pub fn as_comment(&self) -> Option<&CstComment> {
+  pub fn as_comment(&self) -> Option<CstComment> {
     match self {
-      CstNode::Leaf(CstLeafNode::Comment(node)) => Some(node),
+      CstNode::Leaf(CstLeafNode::Comment(node)) => Some(node.clone()),
       _ => None,
     }
   }
@@ -584,33 +585,33 @@ impl CstContainerNode {
   }
 
   /// Node if it's the root node.
-  pub fn as_root(&self) -> Option<&CstRootNode> {
+  pub fn as_root(&self) -> Option<CstRootNode> {
     match self {
-      CstContainerNode::Root(node) => Some(node),
+      CstContainerNode::Root(node) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's an array.
-  pub fn as_array(&self) -> Option<&CstArray> {
+  pub fn as_array(&self) -> Option<CstArray> {
     match self {
-      CstContainerNode::Array(node) => Some(node),
+      CstContainerNode::Array(node) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's an object.
-  pub fn as_object(&self) -> Option<&CstObject> {
+  pub fn as_object(&self) -> Option<CstObject> {
     match self {
-      CstContainerNode::Object(node) => Some(node),
+      CstContainerNode::Object(node) => Some(node.clone()),
       _ => None,
     }
   }
 
   /// Node if it's an object property.
-  pub fn as_object_prop(&self) -> Option<&CstObjectProp> {
+  pub fn as_object_prop(&self) -> Option<CstObjectProp> {
     match self {
-      CstContainerNode::ObjectProp(node) => Some(node),
+      CstContainerNode::ObjectProp(node) => Some(node.clone()),
       _ => None,
     }
   }
@@ -970,8 +971,7 @@ impl CstRootNode {
   /// }"#;
   ///
   /// let node = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
-  /// let root_value = node.root_value().unwrap();
-  /// let root_obj = root_value.as_object().unwrap();
+  /// let root_obj = node.root_value().unwrap().as_object().unwrap();
   ///
   /// root_obj.append("new_key", value!([456, 789, false]));
   ///
@@ -1092,7 +1092,7 @@ impl CstRootNode {
       None => {
         self.set_root_value(CstInputValue::Object(Vec::new()));
         // should always work, but might as well do this
-        self.root_value().and_then(|o| o.as_object().cloned())
+        self.root_value().and_then(|o| o.as_object())
       }
     }
   }
@@ -1530,18 +1530,18 @@ impl ObjectPropName {
   add_parent_info_methods!();
 
   /// Object property name if it's a string literal.
-  pub fn as_string_lit(&self) -> Option<&CstStringLit> {
+  pub fn as_string_lit(&self) -> Option<CstStringLit> {
     match self {
-      ObjectPropName::String(n) => Some(n),
+      ObjectPropName::String(n) => Some(n.clone()),
       ObjectPropName::Word(_) => None,
     }
   }
 
   /// Object property name if it's a word literal (no quotes).
-  pub fn as_word_lit(&self) -> Option<&CstWordLit> {
+  pub fn as_word_lit(&self) -> Option<CstWordLit> {
     match self {
       ObjectPropName::String(_) => None,
-      ObjectPropName::Word(n) => Some(n),
+      ObjectPropName::Word(n) => Some(n.clone()),
     }
   }
 
@@ -3030,7 +3030,7 @@ value3: true
       root_obj
         .children()
         .into_iter()
-        .filter_map(|c| c.as_comment().cloned())
+        .filter_map(|c| c.as_comment())
         .next()
         .unwrap()
         .remove();

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -1321,9 +1321,18 @@ impl CstArray {
       .collect()
   }
 
+  pub fn append(&self, value: RawCstValue) {
+    self.insert_or_append(None, value);
+  }
+
   pub fn insert(&self, index: usize, value: RawCstValue) {
+    self.insert_or_append(Some(index), value);
+  }
+
+  fn insert_or_append(&self, index: Option<usize>, value: RawCstValue) {
     let children = self.children();
     let elements = self.elements();
+    let index = index.unwrap_or(elements.len());
     let index = std::cmp::min(index, elements.len());
     let next_node = elements.get(index);
     let previous_node = if index == 0 { None } else { elements.get(index - 1) };
@@ -2229,7 +2238,7 @@ value3: true
   }
 ]"#,
     );
-    //run_test(0, RawCstValue::Number("10".to_string()), r#"[]"#, r#"[10]"#);
+    run_test(0, RawCstValue::Number("10".to_string()), r#"[]"#, r#"[10]"#);
   }
 
   #[test]

--- a/src/cst/mod.rs
+++ b/src/cst/mod.rs
@@ -964,7 +964,7 @@ impl CstRootNode {
   /// ```
   /// use jsonc_parser::cst::CstRootNode;
   /// use jsonc_parser::ParseOptions;
-  /// use jsonc_parser::value;
+  /// use jsonc_parser::json;
   ///
   /// let json_text = r#"{
   ///    // comment
@@ -974,10 +974,10 @@ impl CstRootNode {
   /// let root = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
   /// let root_obj = root.root_value().unwrap().as_object().unwrap();
   ///
-  /// root_obj.get("data").unwrap().set_value(value!({
+  /// root_obj.get("data").unwrap().set_value(json!({
   ///   "nested": true
   /// }));
-  /// root_obj.append("new_key", value!([456, 789, false]));
+  /// root_obj.append("new_key", json!([456, 789, false]));
   ///
   /// assert_eq!(root.to_string(), r#"{
   ///    // comment
@@ -2599,7 +2599,7 @@ mod test {
   use pretty_assertions::assert_eq;
 
   use crate::cst::CstInputValue;
-  use crate::value;
+  use crate::json;
 
   use super::CstRootNode;
 
@@ -2794,7 +2794,7 @@ value3: true
     run_test(
       0,
       "propName",
-      value!([1]),
+      json!([1]),
       r#"{}"#,
       r#"{
   "propName": [1]
@@ -2805,7 +2805,7 @@ value3: true
     run_test(
       0,
       "value0",
-      value!([1]),
+      json!([1]),
       r#"{
     "value1": 5
 }"#,
@@ -2819,7 +2819,7 @@ value3: true
     run_test(
       0,
       "value0",
-      value!([1]),
+      json!([1]),
       r#"{
     // some comment
     "value1": 5
@@ -2835,7 +2835,7 @@ value3: true
     run_test(
       1,
       "value1",
-      value!({
+      json!({
         "value": 1
       }),
       r#"{
@@ -2853,7 +2853,7 @@ value3: true
     run_test(
       1,
       "propName",
-      value!(true),
+      json!(true),
       r#"{
   "value": 4,
 }"#,
@@ -2946,14 +2946,14 @@ value3: true
       assert_eq!(cst.to_string(), expected, "Initial text: {}", json);
     }
 
-    run_test(0, value!([1]), r#"[]"#, r#"[[1]]"#);
-    run_test(0, value!([1, true, false, {}]), r#"[]"#, r#"[[1, true, false, {}]]"#);
-    run_test(0, value!(10), r#"[]"#, r#"[10]"#);
-    run_test(0, value!(10), r#"[1]"#, r#"[10, 1]"#);
-    run_test(1, value!(10), r#"[1]"#, r#"[1, 10]"#);
+    run_test(0, json!([1]), r#"[]"#, r#"[[1]]"#);
+    run_test(0, json!([1, true, false, {}]), r#"[]"#, r#"[[1, true, false, {}]]"#);
+    run_test(0, json!(10), r#"[]"#, r#"[10]"#);
+    run_test(0, json!(10), r#"[1]"#, r#"[10, 1]"#);
+    run_test(1, json!(10), r#"[1]"#, r#"[1, 10]"#);
     run_test(
       0,
-      value!(10),
+      json!(10),
       r#"[
     1
 ]"#,
@@ -2964,7 +2964,7 @@ value3: true
     );
     run_test(
       0,
-      value!(10),
+      json!(10),
       r#"[
     /* test */ 1
 ]"#,
@@ -2976,7 +2976,7 @@ value3: true
 
     run_test(
       0,
-      value!({
+      json!({
         "value": 1,
       }),
       r#"[]"#,
@@ -2990,7 +2990,7 @@ value3: true
     // only comment
     run_test(
       0,
-      value!({
+      json!({
         "value": 1,
       }),
       r#"[
@@ -3007,7 +3007,7 @@ value3: true
     // blank line
     run_test(
       0,
-      value!({
+      json!({
         "value": 1,
       }),
       r#"[
@@ -3036,7 +3036,7 @@ value3: true
       .unwrap()
       .get_array("prop")
       .unwrap()
-      .append(value!(3));
+      .append(json!(3));
     assert_eq!(
       cst.to_string(),
       r#"{

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,7 +16,7 @@ pub struct ParseError {
 
 impl ParseError {
   pub(crate) fn new(range: Range, message: &str, file_text: &str) -> ParseError {
-    let display_message = get_message_with_range(&range, message, file_text);
+    let display_message = get_message_with_range(range, message, file_text);
     ParseError {
       message: message.to_string(),
       range,
@@ -37,7 +37,7 @@ impl Error for ParseError {
   }
 }
 
-fn get_message_with_range(range: &Range, message: &str, file_text: &str) -> String {
+fn get_message_with_range(range: Range, message: &str, file_text: &str) -> String {
   let mut line_index = 0;
   let mut column_index = 0;
   for c in file_text[..range.start].chars() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod ast;
 pub mod common;
-#[cfg(feature = "serde")]
+#[cfg(feature = "cst")]
 pub mod cst;
 pub mod errors;
 mod parse_to_ast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 pub mod common;
+pub mod cst;
 pub mod errors;
 mod parse_to_ast;
 mod parse_to_value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::print_stderr)]
+#![deny(clippy::print_stdout)]
+
 pub mod ast;
 pub mod common;
 #[cfg(feature = "serde")]
@@ -8,12 +11,14 @@ mod parse_to_value;
 mod scanner;
 #[cfg(feature = "serde")]
 mod serde;
+mod string;
 pub mod tokens;
 mod value;
 
 pub use parse_to_ast::*;
 pub use parse_to_value::*;
 pub use scanner::*;
+pub use string::ParseStringErrorKind;
 pub use value::*;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 pub mod common;
+#[cfg(feature = "serde")]
 pub mod cst;
 pub mod errors;
 mod parse_to_ast;

--- a/src/parse_to_ast.rs
+++ b/src/parse_to_ast.rs
@@ -521,7 +521,7 @@ mod tests {
   #[test]
   fn it_should_not_include_tokens_by_default() {
     let result = parse_to_ast("{}", &Default::default(), &Default::default()).unwrap();
-    assert_eq!(result.tokens.is_none(), true);
+    assert!(result.tokens.is_none());
   }
 
   #[test]
@@ -542,7 +542,7 @@ mod tests {
   #[test]
   fn it_should_not_include_comments_by_default() {
     let result = parse_to_ast("{}", &Default::default(), &Default::default()).unwrap();
-    assert_eq!(result.comments.is_none(), true);
+    assert!(result.comments.is_none());
   }
 
   #[test]

--- a/src/parse_to_value.rs
+++ b/src/parse_to_value.rs
@@ -19,7 +19,7 @@ pub fn parse_to_value<'a>(text: &'a str, options: &ParseOptions) -> Result<Optio
   let value = parse_to_ast(
     text,
     &CollectOptions {
-      comments: false,
+      comments: crate::CommentCollectionStrategy::Off,
       tokens: false,
     },
     options,

--- a/src/parse_to_value.rs
+++ b/src/parse_to_value.rs
@@ -139,7 +139,7 @@ mod tests {
   #[test]
   fn it_should_parse_empty() {
     let value = parse_to_value("", &Default::default()).unwrap();
-    assert_eq!(value.is_none(), true);
+    assert!(value.is_none());
   }
 
   #[test]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -22,7 +22,7 @@ pub fn parse_to_serde_value(text: &str, parse_options: &ParseOptions) -> Result<
   let value = parse_to_ast(
     text,
     &CollectOptions {
-      comments: false,
+      comments: crate::CommentCollectionStrategy::Off,
       tokens: false,
     },
     parse_options,

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,220 @@
+use std::borrow::Cow;
+
+pub struct ParseStringError {
+  pub byte_index: usize,
+  pub kind: ParseStringErrorKind,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ParseStringErrorKind {
+  InvalidEscapeInSingleQuoteString,
+  InvalidEscapeInDoubleQuoteString,
+  ExpectedFourHexDigits,
+  InvalidUnicodeEscapeSequence(String),
+  InvalidEscape,
+  UnterminatedStringLiteral,
+}
+
+impl std::error::Error for ParseStringErrorKind {}
+
+impl std::fmt::Display for ParseStringErrorKind {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      ParseStringErrorKind::InvalidEscapeInSingleQuoteString => {
+        write!(f, "Invalid escape in single quote string")
+      }
+      ParseStringErrorKind::InvalidEscapeInDoubleQuoteString => {
+        write!(f, "Invalid escape in double quote string")
+      }
+      ParseStringErrorKind::ExpectedFourHexDigits => {
+        write!(f, "Expected four hex digits")
+      }
+      ParseStringErrorKind::InvalidUnicodeEscapeSequence(value) => {
+        write!(
+          f,
+          "Invalid unicode escape sequence. '{}' is not a valid UTF8 character",
+          value
+        )
+      }
+      ParseStringErrorKind::InvalidEscape => {
+        write!(f, "Invalid escape")
+      }
+      ParseStringErrorKind::UnterminatedStringLiteral => {
+        write!(f, "Unterminated string literal")
+      }
+    }
+  }
+}
+
+pub trait CharProvider<'a> {
+  fn current_char(&mut self) -> Option<char>;
+  fn byte_index(&self) -> usize;
+  fn move_next_char(&mut self) -> Option<char>;
+  fn text(&self) -> &'a str;
+}
+
+pub fn parse_string(text: &str) -> Result<Cow<str>, ParseStringError> {
+  struct StringCharProvider<'a> {
+    text: &'a str,
+    byte_index: usize,
+    current_char: Option<char>,
+    chars: std::str::Chars<'a>,
+  }
+
+  impl<'a> CharProvider<'a> for StringCharProvider<'a> {
+    fn current_char(&mut self) -> Option<char> {
+      self.current_char
+    }
+
+    fn byte_index(&self) -> usize {
+      self.byte_index
+    }
+
+    fn move_next_char(&mut self) -> Option<char> {
+      if let Some(current_char) = self.current_char {
+        self.byte_index += current_char.len_utf8();
+      }
+      self.current_char = self.chars.next();
+      self.current_char
+    }
+
+    fn text(&self) -> &'a str {
+      self.text
+    }
+  }
+
+  let mut chars = text.chars();
+  let mut provider = StringCharProvider {
+    text,
+    byte_index: 0,
+    current_char: chars.next(),
+    chars,
+  };
+
+  parse_string_with_char_provider(&mut provider)
+}
+
+pub fn parse_string_with_char_provider<'a, T: CharProvider<'a>>(
+  chars: &mut T,
+) -> Result<Cow<'a, str>, ParseStringError> {
+  debug_assert!(
+    chars.current_char() == Some('\'') || chars.current_char() == Some('"'),
+    "Expected \", was {:?}",
+    chars.current_char()
+  );
+  let is_double_quote = chars.current_char() == Some('"');
+  let mut last_start_byte_index = chars.byte_index() + 1;
+  let mut text: Option<String> = None;
+  let mut last_was_backslash = false;
+  let mut found_end_string = false;
+  let token_start = chars.byte_index();
+
+  while let Some(current_char) = chars.move_next_char() {
+    if last_was_backslash {
+      let escape_start = chars.byte_index() - 1; // -1 for backslash
+      match current_char {
+        '"' | '\'' | '\\' | '/' | 'b' | 'f' | 'u' | 'r' | 'n' | 't' => {
+          if current_char == '"' {
+            if !is_double_quote {
+              return Err(ParseStringError {
+                byte_index: escape_start,
+                kind: ParseStringErrorKind::InvalidEscapeInSingleQuoteString,
+              });
+            }
+          } else if current_char == '\'' && is_double_quote {
+            return Err(ParseStringError {
+              byte_index: escape_start,
+              kind: ParseStringErrorKind::InvalidEscapeInDoubleQuoteString,
+            });
+          }
+
+          let previous_text = &chars.text()[last_start_byte_index..escape_start];
+          if text.is_none() {
+            text = Some(String::new());
+          }
+          let text = text.as_mut().unwrap();
+          text.push_str(previous_text);
+          if current_char == 'u' {
+            let mut hex_text = String::new();
+            // expect four hex values
+            for _ in 0..4 {
+              let current_char = chars.move_next_char();
+              if !is_hex(current_char) {
+                return Err(ParseStringError {
+                  byte_index: escape_start,
+                  kind: ParseStringErrorKind::ExpectedFourHexDigits,
+                });
+              }
+              if let Some(current_char) = current_char {
+                hex_text.push(current_char);
+              }
+            }
+
+            let hex_u32 = u32::from_str_radix(&hex_text, 16);
+            let hex_char = match hex_u32.ok().and_then(std::char::from_u32) {
+              Some(hex_char) => hex_char,
+              None => {
+                return Err(ParseStringError {
+                  byte_index: escape_start,
+                  kind: ParseStringErrorKind::InvalidUnicodeEscapeSequence(hex_text),
+                });
+              }
+            };
+            text.push(hex_char);
+            last_start_byte_index = chars.byte_index() + chars.current_char().map(|c| c.len_utf8()).unwrap_or(0);
+          } else {
+            text.push(match current_char {
+              'b' => '\u{08}',
+              'f' => '\u{0C}',
+              't' => '\t',
+              'r' => '\r',
+              'n' => '\n',
+              _ => current_char,
+            });
+            last_start_byte_index = chars.byte_index() + current_char.len_utf8();
+          }
+        }
+        _ => {
+          return Err(ParseStringError {
+            byte_index: escape_start,
+            kind: ParseStringErrorKind::InvalidEscape,
+          });
+        }
+      }
+      last_was_backslash = false;
+    } else if is_double_quote && current_char == '"' || !is_double_quote && current_char == '\'' {
+      found_end_string = true;
+      break;
+    } else {
+      last_was_backslash = current_char == '\\';
+    }
+  }
+
+  if found_end_string {
+    chars.move_next_char();
+    let final_segment = &chars.text()[last_start_byte_index..chars.byte_index() - 1];
+    Ok(match text {
+      Some(mut text) => {
+        text.push_str(final_segment);
+        Cow::Owned(text)
+      }
+      None => Cow::Borrowed(final_segment),
+    })
+  } else {
+    Err(ParseStringError {
+      byte_index: token_start,
+      kind: ParseStringErrorKind::UnterminatedStringLiteral,
+    })
+  }
+}
+
+fn is_hex(c: Option<char>) -> bool {
+  let Some(c) = c else {
+    return false;
+  };
+  is_digit(c) || ('a'..='f').contains(&c) || ('A'..='F').contains(&c)
+}
+
+fn is_digit(c: char) -> bool {
+  c.is_ascii_digit()
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -53,6 +53,7 @@ pub trait CharProvider<'a> {
   fn text(&self) -> &'a str;
 }
 
+#[cfg(feature = "cst")]
 pub fn parse_string(text: &str) -> Result<Cow<str>, ParseStringError> {
   struct StringCharProvider<'a> {
     text: &'a str,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -20,6 +20,32 @@ pub enum Token<'a> {
   CommentBlock(&'a str),
 }
 
+impl<'a> Token<'a> {
+  pub fn as_str(&self) -> &str {
+    match self {
+      Token::OpenBrace => "{",
+      Token::CloseBrace => "}",
+      Token::OpenBracket => "[",
+      Token::CloseBracket => "]",
+      Token::Comma => ",",
+      Token::Colon => ":",
+      Token::String(value) => value,
+      Token::Word(value) => value,
+      Token::Boolean(value) => {
+        if *value {
+          "true"
+        } else {
+          "false"
+        }
+      }
+      Token::Number(value) => value,
+      Token::Null => "null",
+      Token::CommentLine(value) => value,
+      Token::CommentBlock(value) => value,
+    }
+  }
+}
+
 /// A token with positional information.
 pub struct TokenAndRange<'a> {
   pub range: Range,
@@ -27,7 +53,7 @@ pub struct TokenAndRange<'a> {
 }
 
 impl<'a> Ranged for TokenAndRange<'a> {
-  fn range(&self) -> &Range {
-    &self.range
+  fn range(&self) -> Range {
+    self.range
   }
 }

--- a/tests/specs/string/string.json
+++ b/tests/specs/string/string.json
@@ -1,0 +1,4 @@
+[
+  "testing\" testing",
+  "testing\\ testing"
+]

--- a/tests/specs/string/string.txt
+++ b/tests/specs/string/string.txt
@@ -1,0 +1,29 @@
+{
+  "value": {
+    "type": "array",
+    "range": {
+      "start": 0,
+      "end": 48,
+    },
+    "elements": [
+      {
+        "type": "string",
+        "range": {
+          "start": 4,
+          "end": 23,
+        },
+        "value": "testing" testing"
+      },
+      {
+        "type": "string",
+        "range": {
+          "start": 27,
+          "end": 46,
+        },
+        "value": "testing\\ testing"
+      }
+    ]
+  },
+  "comments": [
+  ]
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,9 +13,7 @@ use std::rc::Rc;
 fn test_specs() {
   for json_path in get_json_file_paths_in_dir(&Path::new("./tests/specs")) {
     let text_file_path = json_path.with_extension("txt");
-    let json_file_text = fs::read_to_string(&json_path)
-      .expect("Expected to read file.")
-      .replace("\r\n", "\n");
+    let json_file_text = fs::read_to_string(&json_path).unwrap().replace("\r\n", "\n");
     let result = parse_to_ast(
       &json_file_text,
       &CollectOptions {
@@ -26,11 +24,21 @@ fn test_specs() {
     )
     .expect("Expected no error.");
     let result_text = parse_result_to_test_str(&result);
-    let expected_text = fs::read_to_string(&text_file_path)
-      .expect("Expected to read expected file.")
-      .replace("\r\n", "\n");
+    let expected_text = fs::read_to_string(&text_file_path).unwrap().replace("\r\n", "\n");
     // fs::write(&text_file_path, result_text.clone()).unwrap();
     assert_eq!(result_text.trim(), expected_text.trim());
+  }
+}
+
+#[test]
+fn test_cst() {
+  for json_path in get_json_file_paths_in_dir(&Path::new("./tests/specs")) {
+    let json_file_text = fs::read_to_string(&json_path).unwrap().replace("\r\n", "\n");
+
+    eprintln!("Parsing: {:?}", json_path);
+    let value = jsonc_parser::cst::CstRootNode::parse(&json_file_text, &ParseOptions::default()).unwrap();
+    let cst_string = value.to_string();
+    assert_eq!(cst_string, json_file_text);
   }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,6 +30,7 @@ fn test_specs() {
   }
 }
 
+#[cfg(feature = "cst")]
 #[test]
 fn test_cst() {
   for json_path in get_json_file_paths_in_dir(&Path::new("./tests/specs")) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 
 #[test]
 fn test_specs() {
-  for json_path in get_json_file_paths_in_dir(&Path::new("./tests/specs")) {
+  for json_path in get_json_file_paths_in_dir(Path::new("./tests/specs")) {
     let text_file_path = json_path.with_extension("txt");
     let json_file_text = fs::read_to_string(&json_path).unwrap().replace("\r\n", "\n");
     let result = parse_to_ast(
@@ -33,7 +33,7 @@ fn test_specs() {
 #[cfg(feature = "cst")]
 #[test]
 fn test_cst() {
-  for json_path in get_json_file_paths_in_dir(&Path::new("./tests/specs")) {
+  for json_path in get_json_file_paths_in_dir(Path::new("./tests/specs")) {
     let json_file_text = fs::read_to_string(&json_path).unwrap().replace("\r\n", "\n");
 
     eprintln!("Parsing: {:?}", json_path);
@@ -84,12 +84,12 @@ fn parse_result_to_test_str(parse_result: &ParseResult) -> String {
   let comments = parse_result.comments.as_ref().expect("Expected comments.");
   let collection_count = comments.len();
   let mut comments = comments.iter().collect::<Vec<_>>();
-  comments.sort_by(|a, b| a.0.cmp(&b.0));
+  comments.sort_by(|a, b| a.0.cmp(b.0));
   for (i, comment_collection) in comments.into_iter().enumerate() {
     text.push_str("\n    ");
     text.push_str(&comments_to_test_str(comment_collection).replace("\n", "\n    "));
     if i + 1 < collection_count {
-      text.push_str(",");
+      text.push(',');
     }
   }
   text.push_str("\n  ]\n");
@@ -113,7 +113,7 @@ fn range_to_test_str(range: Range) -> String {
   text.push_str("\"range\": {\n");
   text.push_str(&format!("  \"start\": {},\n", range.start));
   text.push_str(&format!("  \"end\": {},\n", range.end));
-  text.push_str("}");
+  text.push('}');
   text
 }
 
@@ -139,7 +139,7 @@ fn lit_to_test_str(lit_type: &str, value: &str, range: Range) -> String {
   text.push_str(&format!("  \"type\": \"{}\",\n", lit_type));
   text.push_str(&format!("  {},\n", range_to_test_str(range).replace("\n", "\n  ")));
   text.push_str(&format!("  \"value\": \"{}\"\n", escape_json_str(value)));
-  text.push_str("}");
+  text.push('}');
   text
 }
 
@@ -154,11 +154,11 @@ fn object_to_test_str(obj: &Object) -> String {
     text.push_str("\n    ");
     text.push_str(&object_prop_to_test_str(prop).replace("\n", "\n    "));
     if i + 1 < prop_count {
-      text.push_str(",");
+      text.push(',');
     }
   }
   text.push_str("\n  ]\n");
-  text.push_str("}");
+  text.push('}');
   text
 }
 
@@ -178,7 +178,7 @@ fn object_prop_to_test_str(obj_prop: &ObjectProp) -> String {
     "  \"value\": {}\n",
     value_to_test_str(&obj_prop.value).replace("\n", "\n  ")
   ));
-  text.push_str("}");
+  text.push('}');
   text
 }
 
@@ -200,11 +200,11 @@ fn array_to_test_str(arr: &Array) -> String {
     text.push_str("\n    ");
     text.push_str(&value_to_test_str(element).replace("\n", "\n    "));
     if i + 1 < elements_count {
-      text.push_str(",");
+      text.push(',');
     }
   }
   text.push_str("\n  ]\n");
-  text.push_str("}");
+  text.push('}');
   text
 }
 
@@ -216,7 +216,7 @@ fn null_keyword_to_test_str(null_keyword: &NullKeyword) -> String {
     "  {}\n",
     range_to_test_str(null_keyword.range).replace("\n", "\n  ")
   ));
-  text.push_str("}");
+  text.push('}');
   text
 }
 
@@ -230,11 +230,11 @@ fn comments_to_test_str(comments: (&usize, &Rc<Vec<Comment>>)) -> String {
     text.push_str("\n    ");
     text.push_str(&comment_to_test_str(comment).replace("\n", "\n    "));
     if i + 1 < comments_count {
-      text.push_str(",");
+      text.push(',');
     }
   }
   text.push_str("\n  ]\n");
-  text.push_str("}");
+  text.push('}');
   text
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -19,7 +19,7 @@ fn test_specs() {
     let result = parse_to_ast(
       &json_file_text,
       &CollectOptions {
-        comments: true,
+        comments: CommentCollectionStrategy::Separate,
         tokens: true,
       },
       &Default::default(),
@@ -99,7 +99,7 @@ fn value_to_test_str(value: &Value) -> String {
   }
 }
 
-fn range_to_test_str(range: &Range) -> String {
+fn range_to_test_str(range: Range) -> String {
   let mut text = String::new();
   text.push_str("\"range\": {\n");
   text.push_str(&format!("  \"start\": {},\n", range.start));
@@ -109,22 +109,22 @@ fn range_to_test_str(range: &Range) -> String {
 }
 
 fn string_lit_to_test_str(lit: &StringLit) -> String {
-  lit_to_test_str("string", &lit.value, &lit.range)
+  lit_to_test_str("string", &lit.value, lit.range)
 }
 
 fn word_lit_to_test_str(lit: &WordLit) -> String {
-  lit_to_test_str("word", lit.value, &lit.range)
+  lit_to_test_str("word", lit.value, lit.range)
 }
 
 fn number_lit_to_test_str(lit: &NumberLit) -> String {
-  lit_to_test_str("number", lit.value, &lit.range)
+  lit_to_test_str("number", lit.value, lit.range)
 }
 
 fn boolean_lit_to_test_str(lit: &BooleanLit) -> String {
-  lit_to_test_str("boolean", &lit.value.to_string(), &lit.range)
+  lit_to_test_str("boolean", &lit.value.to_string(), lit.range)
 }
 
-fn lit_to_test_str(lit_type: &str, value: &str, range: &Range) -> String {
+fn lit_to_test_str(lit_type: &str, value: &str, range: Range) -> String {
   let mut text = String::new();
   text.push_str("{\n");
   text.push_str(&format!("  \"type\": \"{}\",\n", lit_type));
@@ -138,7 +138,7 @@ fn object_to_test_str(obj: &Object) -> String {
   let mut text = String::new();
   text.push_str("{\n");
   text.push_str("  \"type\": \"object\",\n");
-  text.push_str(&format!("  {},\n", range_to_test_str(&obj.range).replace("\n", "\n  ")));
+  text.push_str(&format!("  {},\n", range_to_test_str(obj.range).replace("\n", "\n  ")));
   text.push_str("  \"properties\": [");
   let prop_count = obj.properties.len();
   for (i, prop) in obj.properties.iter().enumerate() {
@@ -159,7 +159,7 @@ fn object_prop_to_test_str(obj_prop: &ObjectProp) -> String {
   text.push_str("  \"type\": \"objectProp\",\n");
   text.push_str(&format!(
     "  {},\n",
-    range_to_test_str(&obj_prop.range).replace("\n", "\n  ")
+    range_to_test_str(obj_prop.range).replace("\n", "\n  ")
   ));
   text.push_str(&format!(
     "  \"name\": {},\n",
@@ -184,7 +184,7 @@ fn array_to_test_str(arr: &Array) -> String {
   let mut text = String::new();
   text.push_str("{\n");
   text.push_str("  \"type\": \"array\",\n");
-  text.push_str(&format!("  {},\n", range_to_test_str(&arr.range).replace("\n", "\n  ")));
+  text.push_str(&format!("  {},\n", range_to_test_str(arr.range).replace("\n", "\n  ")));
   text.push_str("  \"elements\": [");
   let elements_count = arr.elements.len();
   for (i, element) in arr.elements.iter().enumerate() {
@@ -205,7 +205,7 @@ fn null_keyword_to_test_str(null_keyword: &NullKeyword) -> String {
   text.push_str("  \"type\": \"null\",\n");
   text.push_str(&format!(
     "  {}\n",
-    range_to_test_str(&null_keyword.range).replace("\n", "\n  ")
+    range_to_test_str(null_keyword.range).replace("\n", "\n  ")
   ));
   text.push_str("}");
   text
@@ -237,11 +237,11 @@ fn comment_to_test_str(comment: &Comment) -> String {
 }
 
 fn comment_line_to_test_str(line: &CommentLine) -> String {
-  lit_to_test_str("line", line.text, &line.range)
+  lit_to_test_str("line", line.text, line.range)
 }
 
 fn comment_block_to_test_str(block: &CommentBlock) -> String {
-  lit_to_test_str("block", block.text, &block.range)
+  lit_to_test_str("block", block.text, block.range)
 }
 
 fn escape_json_str(text: &str) -> String {


### PR DESCRIPTION
Adds a CST, which can be manipulated and printed back out to a string.

```rs
use jsonc_parser::cst::CstRootNode;
use jsonc_parser::ParseOptions;
use jsonc_parser::json;

let json_text = r#"{
  // comment
  "data": 123
}"#;

let root = CstRootNode::parse(json_text, &ParseOptions::default()).unwrap();
let root_obj = root.root_value().unwrap().as_object().unwrap();

root_obj.get("data").unwrap().set_value(json!({
  "nested": true
}));
root_obj.append("new_key", json!([456, 789, false]));

assert_eq!(root.to_string(), r#"{
  // comment
  "data": {
    "nested": true,
  },
  "new_key": [456, 789, false]
}"#);
```

Closes https://github.com/dprint/jsonc-parser/issues/40