### PR TITLE
perf(serde): borrow object keys during deserialization to avoid per-key allocation

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -34,6 +34,26 @@ fn key_heavy_json_value(b: &mut Bencher) {
   bench_value(b, &get_key_heavy_json());
 }
 
+// struct deserialization matches keys against static field names, so borrowed
+// keys avoid the per-property allocation entirely (unlike a serde_json::Value
+// target, whose Map must own its keys regardless)
+#[bench]
+#[cfg(feature = "serde")]
+fn key_heavy_json_serde_struct(b: &mut Bencher) {
+  #[derive(serde::Deserialize)]
+  #[allow(dead_code)]
+  struct Item {
+    id: u32,
+    name: String,
+    kind: String,
+    enabled: bool,
+    count: u32,
+    tag: String,
+  }
+  let json = get_key_heavy_json();
+  b.iter(|| jsonc_parser::parse_to_serde_value::<Vec<Item>>(&json, &Default::default()).unwrap());
+}
+
 #[bench]
 fn tsconfig_json_ast(b: &mut Bencher) {
   bench_ast(b, &get_tsconfig_json());

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -332,9 +332,12 @@ impl<'de, 'b> MapAccess<'de> for ScannerMapAccess<'de, 'b> {
     match key {
       None => Ok(None),
       Some(key) => {
-        let key_str = key.into_string();
+        // borrow the key from the source when it's clean, only allocating for
+        // owned (escaped) keys — mirrors the value path's `Cow` keys
         seed
-          .deserialize(<String as IntoDeserializer<Self::Error>>::into_deserializer(key_str))
+          .deserialize(<Cow<'de, str> as IntoDeserializer<Self::Error>>::into_deserializer(
+            key.into_cow(),
+          ))
           .map(Some)
       }
     }


### PR DESCRIPTION
| Bench | Before | After | Result |
  |---|---|---|---|
  | `key_heavy_json_serde_struct` | 7,987,740 ns | 5,637,590 ns | **−29.4%** (1.42×) |
  | `package_json_serde_value` | 26,536 ns | 26,572 ns | flat (no regression) |
  | `tsconfig_json_serde_value` | 2,356 ns | 2,347 ns | flat (no regression) |
  | `citm_catalog_json_large_serde_value` | 27,578,010 ns | 28,703,940 ns | flat (within noise) |