### PR TITLE
fix(serde): error instead of returning `null` for numbers out of range

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -230,10 +230,15 @@ fn visit_number<'de, V: Visitor<'de>>(raw: &str, visitor: V) -> Result<V::Value,
   let trimmed = raw.trim_start_matches(['-', '+']);
   if trimmed.len() > 2 && (trimmed.starts_with("0x") || trimmed.starts_with("0X")) {
     let hex_part = &trimmed[2..];
-    // parse as an i128 so that values up to u64::MAX and down to i64::MIN fit
+    let negative = raw.starts_with('-');
+    if let Ok(val) = i64::from_str_radix(hex_part, 16) {
+      return visitor.visit_i64(if negative { -val } else { val });
+    }
+    // fall back to an i128 for the values that don't fit in an i64, which
+    // are the ones that fit in a u64 and `i64::MIN`
     return match i128::from_str_radix(hex_part, 16) {
       Ok(val) => {
-        let val = if raw.starts_with('-') { -val } else { val };
+        let val = if negative { -val } else { val };
         if let Ok(val) = i64::try_from(val) {
           visitor.visit_i64(val)
         } else if let Ok(val) = u64::try_from(val) {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -230,13 +230,20 @@ fn visit_number<'de, V: Visitor<'de>>(raw: &str, visitor: V) -> Result<V::Value,
   let trimmed = raw.trim_start_matches(['-', '+']);
   if trimmed.len() > 2 && (trimmed.starts_with("0x") || trimmed.starts_with("0X")) {
     let hex_part = &trimmed[2..];
-    match i64::from_str_radix(hex_part, 16) {
+    // parse as an i128 so that values up to u64::MAX and down to i64::MIN fit
+    return match i128::from_str_radix(hex_part, 16) {
       Ok(val) => {
         let val = if raw.starts_with('-') { -val } else { val };
-        return visitor.visit_i64(val);
+        if let Ok(val) = i64::try_from(val) {
+          visitor.visit_i64(val)
+        } else if let Ok(val) = u64::try_from(val) {
+          visitor.visit_u64(val)
+        } else {
+          Err(number_out_of_range_error())
+        }
       }
-      Err(_) => return visitor.visit_str(raw),
-    }
+      Err(_) => Err(number_out_of_range_error()),
+    };
   }
 
   // strip unary plus
@@ -248,12 +255,19 @@ fn visit_number<'de, V: Visitor<'de>>(raw: &str, visitor: V) -> Result<V::Value,
   if let Ok(v) = num_str.parse::<u64>() {
     return visitor.visit_u64(v);
   }
-  if let Ok(v) = num_str.parse::<f64>() {
-    return visitor.visit_f64(v);
+  match num_str.parse::<f64>() {
+    Ok(v) if v.is_finite() => visitor.visit_f64(v),
+    // `parse` resolves to infinity instead of erroring for numbers that are
+    // too large and the scanner only ever provides numbers an f64 can parse
+    _ => Err(number_out_of_range_error()),
   }
+}
 
-  // fallback for unparseable numbers
-  visitor.visit_str(raw)
+/// Errors instead of silently changing the value's JSON type, which is what
+/// visiting a non-finite float would do (ex. `serde_json::Value` turns those
+/// into `null`).
+fn number_out_of_range_error() -> ParseError {
+  ParseError::custom_err("Number is out of range".to_string())
 }
 
 // array handling
@@ -528,6 +542,54 @@ mod tests {
     );
 
     assert_eq!(result, SerdeValue::Object(expected_value));
+  }
+
+  #[test]
+  fn it_should_error_when_number_is_out_of_f64_range() {
+    assert_has_error(r#"{ "amount": 1e400 }"#, "Number is out of range on line 1 column 13");
+    assert_has_error("[-1e400]", "Number is out of range on line 1 column 2");
+    assert_has_error("1.7976931348623159e308", "Number is out of range on line 1 column 1");
+
+    // deserializing to a float should error as well instead of resolving to infinity
+    let err = parse_to_serde_value::<f64>("1e400", &Default::default()).unwrap_err();
+    assert_eq!(err.to_string(), "Number is out of range on line 1 column 1");
+
+    // the number being out of range still errors when the value is ignored
+    #[derive(::serde::Deserialize, Debug, PartialEq)]
+    #[serde(crate = "::serde")]
+    struct Amount {
+      amount: u32,
+    }
+    let err = parse_to_serde_value::<Amount>(r#"{ "amount": 1, "other": 1e400 }"#, &Default::default()).unwrap_err();
+    assert_eq!(err.to_string(), "Number is out of range on line 1 column 25");
+
+    // numbers that underflow are fine
+    let result = parse_to_serde_value::<f64>("1e-400", &Default::default()).unwrap();
+    assert_eq!(result, 0.0);
+    let result = parse_to_serde_value::<f64>("-1e-400", &Default::default()).unwrap();
+    assert_eq!(result, -0.0);
+    assert!(result.is_sign_negative());
+
+    // the largest finite f64 is fine
+    let result = parse_to_serde_value::<f64>("1.7976931348623157e308", &Default::default()).unwrap();
+    assert_eq!(result, f64::MAX);
+  }
+
+  #[test]
+  fn it_should_error_when_hexadecimal_number_is_out_of_range() {
+    assert_has_error(
+      r#"{ "value": 0xFFFFFFFFFFFFFFFFFF }"#,
+      "Number is out of range on line 1 column 12",
+    );
+    assert_has_error("-0x8000000000000001", "Number is out of range on line 1 column 1");
+
+    // hexadecimal numbers that don't fit in an i64, but fit in a u64
+    let result = parse_to_serde_value::<u64>("0x8000000000000000", &Default::default()).unwrap();
+    assert_eq!(result, 9223372036854775808);
+
+    // i64::MIN
+    let result = parse_to_serde_value::<i64>("-0x8000000000000000", &Default::default()).unwrap();
+    assert_eq!(result, i64::MIN);
   }
 
   #[test]


### PR DESCRIPTION
Closes #85

## Problem

A JSON number too large for an `f64` silently deserialized to `null`:

```rust
let j: serde_json::Value = parse_to_serde_value("{\"amount\": 1e400}", &Default::default()).unwrap();
assert_eq!(j.to_string(), "{\"amount\":null}"); // passed
```

`str::parse::<f64>` resolves to `f64::INFINITY` instead of erroring, and `serde_json`'s `Value` visitor routes non-finite floats through `Number::from_f64`, which returns `None` and produces `Value::Null`. Deserializing to a plain `f64` yielded `inf`.

## Fix

`visit_number` now returns a `ParseError` when the number can't be represented, so `{ "amount": 1e400 }` errors with `Number is out of range on line 1 column 13`. This matches `serde_json::from_str`, which errors with `number out of range` for the same input.

While in there, the hexadecimal branch had the same class of bug — it fell back to visiting the raw literal as a *string* when it didn't fit in an `i64`. It now:

- errors for out of range values (ex. `0xFFFFFFFFFFFFFFFFFF`), instead of deserializing as `"0xFFFFFFFFFFFFFFFFFF"`
- parses via `i128` so values that fit in a `u64` (ex. `0x8000000000000000`) and `-0x8000000000000000` (exactly `i64::MIN`) deserialize as numbers, instead of as strings

The trailing `visitor.visit_str(raw)` fallback for unparseable decimals is gone since it was unreachable — every number token the scanner produces is valid Rust float syntax, so `parse::<f64>` only ever fails to give a usable value by overflowing.

## Behaviour change

Input that previously deserialized (as `null`, `inf`, or a string) now errors, including when the value's field is ignored by the target type — `serde_json` errors there too.

Note this leaves the non-serde conversions diverging: `impl From<ast::Value> for serde_json::Value` and `CstNumberLit::to_serde_value` still turn `1e400` into `Value::String("1e400")`, and their signatures (`From` / `-> Option<_>`) can't surface a parse error. Happy to follow up if you'd like those to return `None` or be documented.

## Tests

Added `it_should_error_when_number_is_out_of_f64_range` and `it_should_error_when_hexadecimal_number_is_out_of_range`, covering positive/negative overflow, error positions, the largest finite `f64`, underflow to `±0.0`, out-of-range values in ignored fields, and the hex cases above.
